### PR TITLE
Fix evaluator input validation and metric boundary handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 # instruction for pypi
 update_pypi.text
 
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 2026-06-11: Version 0.6.3
+
+1. Fix zero-padding and prediction-input update paths so 1-D survival curves, raw replacements after padding, sample-specific time grids, and row-count mismatches are handled consistently in right- and interval-censored evaluators.
+2. Make string option handling case-insensitive across evaluator methods, interpolation choices, Brier score, concordance, calibration, residual, mean-error, and nonparametric estimator settings.
+3. Correct boundary handling for censored observations at target times in AUC and right-censored Brier score calculations, and for open-left/closed-right interval-censored Brier score cases.
+4. Improve utility behavior for repeated infinite monotonic values, degenerate all-one survival-to-quantile curves, zero-padded probability prediction, and vectorized tail extrapolation for multiple target times.
+5. Clean up evaluator prediction input APIs by adding shared `set_prediction_inputs`, refreshing dimension metadata and cached predictions on updates, and accepting list quantile levels.
+6. Correct setup license metadata to GPLv3 and align documentation/comments for evaluator, interval-censored, Brier score, and utility behavior.
+7. Add regression tests covering the new validation, boundary, zero-padding, quantile, utility, and metric behavior.
+
 ## 2026-06-08: Version 0.6.2
 
 1. Improve survival-curve and time-coordinate validation, broadcasting, zero-padding, and monotonicity correction, including isotonic regression support.

--- a/SurvivalEVAL/Evaluations/AreaUnderROCurve.py
+++ b/SurvivalEVAL/Evaluations/AreaUnderROCurve.py
@@ -38,10 +38,13 @@ def auc(
         event_times < target_time, event_indicators == 0
     )
     event_times = event_times[~exclude_indicators]
+    event_indicators = event_indicators[~exclude_indicators]
     predict_probs = predict_probs[~exclude_indicators]
 
     # get the binary status of the test data, given the target time
-    binary_status = (event_times <= target_time).astype(int)
+    binary_status = ((event_times <= target_time) & event_indicators.astype(bool)).astype(
+        int
+    )
 
     # check if the binary status is all zeros or all ones
     if np.all(binary_status == 0) or np.all(binary_status == 1):

--- a/SurvivalEVAL/Evaluations/BrierScore.py
+++ b/SurvivalEVAL/Evaluations/BrierScore.py
@@ -229,12 +229,13 @@ def brier_score_ic(
         else:
             raise ValueError(f"Method {method} is not supported.")
         # exam on non-bad indices
-        # bad indices are those (1) the target time is within the interval and (2) the left and right survival
+        # bad indices are those (1) the target time is strictly inside the
+        # interval and (2) the left and right survival
         # probabilities are the same, which leads to zeros in both numerator and denominator in survival_status
         bad = (
             (left_probs == right_probs)
             & (left_limits < target_time)
-            & (target_time <= right_limits)
+            & (target_time < right_limits)
         )
         if np.sum(bad) > 0:
             left_limits = left_limits[~bad]
@@ -248,8 +249,10 @@ def brier_score_ic(
         # supress warnings for divide by zero
         with np.errstate(divide="ignore", invalid="ignore"):
             survival_status = (target_probs - right_probs) / (left_probs - right_probs)
-        survival_status[right_limits < target_time] = 0
+        # Intervals are left-open, right-closed: (left, right].
+        # At t <= left the subject is alive; at t >= right the event has occurred.
         survival_status[left_limits >= target_time] = 1
+        survival_status[right_limits <= target_time] = 0
 
         if np.any((survival_status < 0) | (survival_status > 1)):
             raise ValueError(
@@ -544,15 +547,15 @@ def brier_multiple_points_ic(
         # --------------------------------------------------------
         # 2B. Build Y_mat (fractional survival status) for every (i,j)
         # --------------------------------------------------------
-        # We'll follow your single-time logic:
+        # We'll follow the single-time logic:
         # survival_status = (S(t) - S(R)) / (S(L) - S(R))
-        # Then override based on position of t relative to [L,R].
+        # Then override based on position of t relative to (L,R].
         #
         # Edge cases:
-        # - If denominator is 0 *and* t is strictly inside (L,R], we can't define status. We'll drop those cells.
+        # - If denominator is 0 *and* t is strictly inside (L,R), we can't define status. We'll drop those cells.
         # - After override:
-        #       if t_j > R_i  -> 0
         #       if t_j <= L_i -> 1
+        #       if t_j >= R_i -> 0
         # This guarantees values in [0,1].
 
         denom = left_probs_mat - right_probs_mat
@@ -560,15 +563,16 @@ def brier_multiple_points_ic(
         with np.errstate(divide="ignore", invalid="ignore"):
             survival_status_mat = (target_probs_mat - right_probs_mat) / denom
 
-        # Apply boundary overrides
-        after_right_mask = time_mat > right_mat
+        # Intervals are left-open, right-closed: (left, right].
+        # Apply the right boundary last so exact intervals are dead at t == right.
+        at_or_after_right_mask = time_mat >= right_mat
         before_left_mask = time_mat <= left_mat
-        survival_status_mat[after_right_mask] = 0.0
         survival_status_mat[before_left_mask] = 1.0
+        survival_status_mat[at_or_after_right_mask] = 0.0
 
         # Identify "bad" cells:
-        # bad if denom == 0 AND t_j is within (L_i, R_i] (i.e. genuinely ambiguous)
-        inside_mask = (time_mat > left_mat) & (time_mat <= right_mat)
+        # bad if denom == 0 AND t_j is within (L_i, R_i) (i.e. genuinely ambiguous)
+        inside_mask = (time_mat > left_mat) & (time_mat < right_mat)
         bad_mask = (denom == 0.0) & inside_mask
 
         # sanity check: any out-of-range due to numerical issues?

--- a/SurvivalEVAL/Evaluations/BrierScore.py
+++ b/SurvivalEVAL/Evaluations/BrierScore.py
@@ -152,6 +152,8 @@ def brier_score_ic(
         tau = np.unique(np.sort(tau_vals))
         target_time = np.median(tau)
 
+    method = method.lower()
+
     if method == "uncensored":
         # If the target time lies within the censoring interval, the event status
         # is ambiguous and the sample is excluded.
@@ -162,7 +164,7 @@ def brier_score_ic(
         # if the right limit is less than or equal to the target time, then the event has occurred, so 0
         survival_status = (left_limits > target_time).astype(float)
         brier_score = (np.square(preds - survival_status) * weight).sum() / weight.sum()
-    elif "Tsouprou" in method:
+    elif method in {"tsouprou-marginal", "tsouprou-conditional"}:
         # method based on Sofia Tsouprou's thesis
         # Measures of discrimination and predictive accuracy for interval censored survival data
         # https://studenttheses.universiteitleiden.nl/access/item:3597164/view
@@ -173,7 +175,7 @@ def brier_score_ic(
         if train_left_limits is None or train_right_limits is None:
             raise ValueError("Training data must be provided for Tsouprou methods.")
 
-        if method == "Tsouprou-marginal":
+        if method == "tsouprou-marginal":
             marginal_estimator = TurnbullEstimatorLifelines(
                 left=train_left_limits,
                 right=train_right_limits,
@@ -182,7 +184,7 @@ def brier_score_ic(
             left_probs = marginal_estimator.predict(left_limits)
             right_probs = marginal_estimator.predict(right_limits)
             target_probs = marginal_estimator.predict(target_time)
-        elif method == "Tsouprou-conditional":
+        elif method == "tsouprou-conditional":
             if x is None or x_train is None:
                 raise ValueError(
                     "Features for both training and testing data must be provided for "
@@ -425,6 +427,8 @@ def brier_multiple_points_ic(
     # ============================================================
     # Case 1: 'uncensored' (naive treating intervals like exact-ish)
     # ============================================================
+    method = method.lower()
+
     if method == "uncensored":
         # For each (i,j), define survival_status_ij in {0,1}:
         #   if t_j < L_i  -> alive -> 1
@@ -464,14 +468,14 @@ def brier_multiple_points_ic(
     # ============================================================
     # Case 2/3: Tsouprou-based, which creates fractional "status"
     # ============================================================
-    if "Tsouprou" in method:
+    if method in {"tsouprou-marginal", "tsouprou-conditional"}:
         if train_left_limits is None or train_right_limits is None:
             raise ValueError("Training data must be provided for Tsouprou methods.")
 
         # --------------------------------------------------------
         # 2A. Fit marginal or conditional model on training data
         # --------------------------------------------------------
-        if method == "Tsouprou-marginal":
+        if method == "tsouprou-marginal":
             marginal_estimator = TurnbullEstimatorLifelines(
                 left=train_left_limits,
                 right=train_right_limits,
@@ -491,7 +495,7 @@ def brier_multiple_points_ic(
                 target_probs_vec.reshape(1, -1), n_samples, axis=0
             )
 
-        elif method == "Tsouprou-conditional":
+        elif method == "tsouprou-conditional":
             if x is None or x_train is None:
                 raise ValueError(
                     "x and x_train must be provided for Tsouprou-conditional."

--- a/SurvivalEVAL/Evaluations/BrierScore.py
+++ b/SurvivalEVAL/Evaluations/BrierScore.py
@@ -52,6 +52,10 @@ def single_brier_score(
 
     event_indicators = event_indicators.astype(bool)
     # train_event_indicators = train_event_indicators.astype(bool)
+    event_before_or_at_target = (event_times <= target_time) & event_indicators
+    event_free_at_target = (event_times > target_time) | (
+        (event_times == target_time) & ~event_indicators
+    )
 
     if ipcw:
         inverse_train_event_indicators = 1 - train_event_indicators
@@ -62,17 +66,20 @@ def single_brier_score(
         ipc_pred[ipc_pred == 0] = np.inf
         # Category one calculates IPCW weight at observed time point.
         # Category one is individuals with event time lower than the time of interest and were NOT censored.
-        weight_cat1 = ((event_times <= target_time) & event_indicators) / ipc_pred
+        weight_cat1 = event_before_or_at_target / ipc_pred
         # Defensively discard any undefined IPCW weights.
         weight_cat1[np.isnan(weight_cat1)] = 0
         # Category 2 is individuals whose time was greater than the time of interest (singleBrierTime)
         # contain both censored and uncensored individuals.
-        weight_cat2 = (event_times > target_time) / ipc_model.predict(target_time)
+        ipc_target_pred = ipc_model.predict(target_time)
+        if ipc_target_pred == 0:
+            ipc_target_pred = np.inf
+        weight_cat2 = event_free_at_target / ipc_target_pred
         # Defensively discard any undefined IPCW weights.
         weight_cat2[np.isnan(weight_cat2)] = 0
     else:
-        weight_cat1 = (event_times <= target_time) & event_indicators
-        weight_cat2 = event_times > target_time
+        weight_cat1 = event_before_or_at_target
+        weight_cat2 = event_free_at_target
 
     b_score = (
         np.square(preds) * weight_cat1 + np.square(1 - preds) * weight_cat2
@@ -319,6 +326,12 @@ def brier_multiple_points(
         event_indicators.reshape(-1, 1), repeats=len(target_times), axis=1
     )
     event_indicators_mat = event_indicators_mat.astype(bool)
+    event_before_or_at_target = (
+        event_times_mat <= target_times_mat
+    ) & event_indicators_mat
+    event_free_at_target = (event_times_mat > target_times_mat) | (
+        (event_times_mat == target_times_mat) & ~event_indicators_mat
+    )
 
     if ipcw:
         if train_event_times is None or train_event_indicators is None:
@@ -335,9 +348,7 @@ def brier_multiple_points(
         ipc_pred = ipc_model.predict(event_times_mat)
         # Catch if denominator is 0.
         ipc_pred[ipc_pred == 0] = np.inf
-        weight_cat1 = (
-            (event_times_mat <= target_times_mat) & event_indicators_mat
-        ) / ipc_pred
+        weight_cat1 = event_before_or_at_target / ipc_pred
         # Defensively discard any undefined IPCW weights.
         weight_cat1[np.isnan(weight_cat1)] = 0
         # Category 2 is individuals whose time was greater than the time of interest (singleBrierTime)
@@ -345,12 +356,12 @@ def brier_multiple_points(
         ipc_target_pred = ipc_model.predict(target_times_mat)
         # Catch if denominator is 0.
         ipc_target_pred[ipc_target_pred == 0] = np.inf
-        weight_cat2 = (event_times_mat > target_times_mat) / ipc_target_pred
+        weight_cat2 = event_free_at_target / ipc_target_pred
         # Defensively discard any undefined IPCW weights.
         weight_cat2[np.isnan(weight_cat2)] = 0
     else:
-        weight_cat1 = (event_times_mat <= target_times_mat) & event_indicators_mat
-        weight_cat2 = event_times_mat > target_times_mat
+        weight_cat1 = event_before_or_at_target
+        weight_cat2 = event_free_at_target
 
     ipcw_square_error_mat = (
         np.square(pred_mat) * weight_cat1 + np.square(1 - pred_mat) * weight_cat2

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -74,11 +74,14 @@ def concordance(
         len(predicted_times) == len(event_times) == len(event_indicators)
     ), "The lengths of the predicted times and labels must be the same."
 
-    if method == "Harrell":
+    method = method.lower()
+    ties = ties.lower()
+
+    if method == "harrell":
         risks = -1 * predicted_times
         partial_weights = None
         bg_event_times = None
-    elif method == "Margin":
+    elif method == "margin":
         if train_event_times is None or train_event_indicators is None:
             error = "If 'Margin' is chosen, training set information must be provided."
             raise ValueError(error)
@@ -125,19 +128,19 @@ def concordance(
         bg_event_time=bg_event_times,
         partial_weights=partial_weights,
     )
-    if ties == "None":
+    if ties == "none":
         total_pairs = concordant_pairs + discordant_pairs
         c_index = concordant_pairs / total_pairs
-    elif ties == "Time":
+    elif ties == "time":
         total_pairs = concordant_pairs + discordant_pairs + time_ties
         concordant_pairs = concordant_pairs + 0.5 * time_ties
         c_index = concordant_pairs / total_pairs
-    elif ties == "Risk":
+    elif ties == "risk":
         # This should be the same as original outputted c_index from above
         total_pairs = concordant_pairs + discordant_pairs + risk_ties
         concordant_pairs = concordant_pairs + 0.5 * risk_ties
         c_index = concordant_pairs / total_pairs
-    elif ties == "All":
+    elif ties == "all":
         total_pairs = concordant_pairs + discordant_pairs + risk_ties + time_ties
         concordant_pairs = concordant_pairs + 0.5 * (risk_ties + time_ties)
         c_index = concordant_pairs / total_pairs
@@ -533,6 +536,9 @@ def concordance_ic(
     # Basic sanity
     if np.any(l > r):
         raise ValueError("Found an interval with left > right in testing data.")
+
+    method = method.lower()
+    ties = ties.lower()
 
     if method == "probability":
         if left_train is None or right_train is None:

--- a/SurvivalEVAL/Evaluations/DistributionCalibration.py
+++ b/SurvivalEVAL/Evaluations/DistributionCalibration.py
@@ -370,11 +370,11 @@ def create_interval_c_hist(
 
 
 _residual_names = {
-    "CoxSnell": "Cox-Snell Residuals",
-    "Modified CoxSnell-v1": "Cox-Snell Residuals",
-    "Modified CoxSnell-v2": "Cox-Snell Residuals",
-    "Martingale": "Martingale Residuals",
-    "Deviance": "Deviance Residuals",
+    "coxsnell": "Cox-Snell Residuals",
+    "modified coxsnell-v1": "Cox-Snell Residuals",
+    "modified coxsnell-v2": "Cox-Snell Residuals",
+    "martingale": "Martingale Residuals",
+    "deviance": "Deviance Residuals",
 }
 
 
@@ -407,20 +407,21 @@ def residuals(
         The calculated residuals.
     """
     cox_residuals = -np.log(pred_probs)
+    method = method.lower()
 
-    if method == "CoxSnell":
+    if method == "coxsnell":
         residuals = cox_residuals
-    elif method == "Modified CoxSnell-v1" or method == "Modified CoxSnell-v2":
+    elif method in ["modified coxsnell-v1", "modified coxsnell-v2"]:
         # Compare with standard CoxSnell residuals, this method adds an 'excess residual' for censored instances.
         # The excess residual should also follow a unit exponential distribution, based on the lack of memory property.
         # There are two choices of excess residuals:
         # (1) use the mean of the unit exponential distribution, which is 1,
         # or (2) use the median of the unit exponential distribution, which is ln(2).
-        excess_residual = 1 if method == "Modified CoxSnell-v1" else np.log(2)
+        excess_residual = 1 if method == "modified coxsnell-v1" else np.log(2)
         residuals = cox_residuals + excess_residual * (1 - event_indicators)
-    elif method == "Martingale":
+    elif method == "martingale":
         residuals = event_indicators - cox_residuals
-    elif method == "Deviance":
+    elif method == "deviance":
 
         def safe_log(x):
             return np.log(x + 1e-8)
@@ -636,6 +637,7 @@ def coverage_ic(
             "pred_l, pred_r, obs_l, and obs_r must contain the same number of samples."
         )
 
+    method = method.lower()
     if method == "linear":
         # Linear interpolation method, assumes uniform distribution within each censoring interval
         overlap_left = np.maximum(obs_l, pred_l)
@@ -643,7 +645,7 @@ def coverage_ic(
 
         denom = obs_r - obs_l
         numer = np.maximum(0.0, overlap_right - overlap_left)
-    elif method == "Turnbull":
+    elif method == "turnbull":
         # error if training is None
         if obs_l_train is None or obs_r_train is None:
             raise ValueError(

--- a/SurvivalEVAL/Evaluations/MeanError.py
+++ b/SurvivalEVAL/Evaluations/MeanError.py
@@ -63,8 +63,11 @@ def mean_error(
     if train_event_indicators is not None:
         train_event_indicators = train_event_indicators.astype(bool)
 
+    error_type = error_type.lower()
+    method = method.lower()
+
     # calculate the weighting for each sample
-    if method in ["Margin", "IPCW-T", "IPCW-D", "Pseudo_obs"]:
+    if method in ["margin", "ipcw-t", "ipcw-d", "pseudo_obs"]:
         if train_event_times is None or train_event_indicators is None:
             raise ValueError(
                 "If method is '{}', training set values must be included.".format(
@@ -93,7 +96,7 @@ def mean_error(
             "Please enter one of 'absolute' or 'squared' for calculating error."
         )
 
-    if method == "Uncensored":
+    if method == "uncensored":
         # only use uncensored data
         if log_scale:
             errors = np.log(event_times[event_indicators]) - np.log(
@@ -102,7 +105,7 @@ def mean_error(
         else:
             errors = event_times[event_indicators] - predicted_times[event_indicators]
         return error_func(errors).mean()
-    elif method == "Hinge":
+    elif method == "hinge":
         # consider only the early prediction error
         # if prediction is higher than the censored time, it is not penalized
         weights = np.ones(predicted_times.size)
@@ -121,7 +124,7 @@ def mean_error(
             errors = event_times - predicted_times
         errors[~event_indicators] = np.maximum(errors[~event_indicators], 0)
         return np.average(error_func(errors), weights=weights)
-    elif method == "Margin":
+    elif method == "margin":
         # The L1-margin method proposed by https://www.jmlr.org/papers/v21/18-772.html
         # Calculate the best guess survival time given the KM curve and censoring time of that patient
         best_guesses = km_model.best_guess(censor_times)
@@ -150,7 +153,7 @@ def mean_error(
                 best_guesses - predicted_times[~event_indicators]
             )
         return np.average(error_func(errors), weights=weights)
-    elif method == "IPCW-T":
+    elif method == "ipcw-t":
         # This is the IPCW-T method from https://arxiv.org/pdf/2306.01196.pdf
         # Calculate the best guess time (surrogate time) based on the subsequent uncensored subjects
         best_guesses = np.empty(shape=n_test)
@@ -180,7 +183,7 @@ def mean_error(
         else:
             errors = best_guesses - predicted_times
         return np.average(error_func(errors), weights=weights)
-    elif method == "IPCW-D":
+    elif method == "ipcw-d":
         # This is the IPCW-D method from https://arxiv.org/pdf/2306.01196.pdf
         # Using IPCW weights to transfer the censored subjects to uncensored subjects
         inverse_train_event_indicators = 1 - train_event_indicators
@@ -201,7 +204,7 @@ def mean_error(
         return (
             error_func(errors)[event_indicators] / ipc_pred[event_indicators]
         ).mean()
-    elif method == "Pseudo_obs":
+    elif method == "pseudo_obs":
         # Calculate the best guess time (surrogate time) by the contribution of the censored subjects to KM curve
         n_train = train_event_times.size
 
@@ -450,6 +453,7 @@ def mean_error_ic(
     L, R, t_hat = _prepare_interval_arrays(left_bounds, right_bounds, predicted_times)
 
     # set the error function
+    error_type = error_type.lower()
     if error_type == "absolute":
         error_func = np.abs
     elif error_type == "squared":

--- a/SurvivalEVAL/Evaluations/SingleTimeCalibration.py
+++ b/SurvivalEVAL/Evaluations/SingleTimeCalibration.py
@@ -74,7 +74,10 @@ def one_calibration(
     expected_probabilities: list
         The expected probabilities in each bin.
     """
-    if binning_strategy == "C":
+    binning_strategy = binning_strategy.lower()
+    method = method.lower()
+
+    if binning_strategy == "c":
         sorted_idx = np.argsort(-preds)
         sorted_predictions = preds[sorted_idx]
         sorted_event_time = event_time[sorted_idx]
@@ -83,7 +86,7 @@ def one_calibration(
         binned_event_time = np.array_split(sorted_event_time, num_bins)
         binned_event_indicator = np.array_split(sorted_event_indicator, num_bins)
         binned_predictions = np.array_split(sorted_predictions, num_bins)
-    elif binning_strategy == "H":
+    elif binning_strategy == "h":
         binned_event_time = []
         binned_event_indicator = []
         binned_predictions = []
@@ -111,7 +114,7 @@ def one_calibration(
 
         # For Uncensored method, we simply remove the censored patients,
         # for D'Agostina-Nam method, we will use 1-KM(t) as the observed probability.
-        if method == "Uncensored":
+        if method == "uncensored":
             filter_idx = ~(
                 (binned_event_time[b] < target_time) & (binned_event_indicator[b] == 0)
             )
@@ -127,7 +130,7 @@ def one_calibration(
             hl_statistics += (event_count - retained_bin_size * mean_prob) ** 2 / (
                 retained_bin_size * mean_prob * (1 - mean_prob)
             )
-        elif method == "DN":
+        elif method == "dn":
             mean_prob = np.mean(binned_predictions[b])
             km_model = KaplanMeier(binned_event_time[b], binned_event_indicator[b])
             event_probability = 1 - km_model.predict(target_time)
@@ -143,7 +146,7 @@ def one_calibration(
     # recalculate the number of bins as the number of bins with data
     num_bins = len(observed_probabilities)
     degree_of_freedom = (
-        num_bins - 1 if (num_bins <= 15 and method == "DN") else num_bins - 2
+        num_bins - 1 if (num_bins <= 15 and method == "dn") else num_bins - 2
     )
     if degree_of_freedom <= 0:
         raise ValueError(
@@ -199,7 +202,10 @@ def one_cal_ic(
     expected_probabilities: list
         The expected probabilities in each bin.
     """
-    if binning_strategy == "C":
+    binning_strategy = binning_strategy.lower()
+    method = method.lower()
+
+    if binning_strategy == "c":
         sorted_idx = np.argsort(-preds)
         sorted_predictions = preds[sorted_idx]
         sorted_left = left_limits[sorted_idx]
@@ -208,7 +214,7 @@ def one_cal_ic(
         binned_left = np.array_split(sorted_left, num_bins)
         binned_right = np.array_split(sorted_right, num_bins)
         binned_predictions = np.array_split(sorted_predictions, num_bins)
-    elif binning_strategy == "H":
+    elif binning_strategy == "h":
         binned_left = []
         binned_right = []
         binned_predictions = []
@@ -237,7 +243,7 @@ def one_cal_ic(
         r_limits = np.array(binned_right[b])
         mean_prob = np.mean(binned_predictions[b])
 
-        if method == "MidPoint":
+        if method == "midpoint":
             mid = l_limits + (r_limits - l_limits) / 2.0
             finite_mid = np.isfinite(mid)
             event_times = np.where(finite_mid, mid, l_limits)
@@ -245,7 +251,7 @@ def one_cal_ic(
 
             km_model = KaplanMeier(event_times, event_indicators)
             event_probability = 1 - km_model.predict(target_time)
-        elif method == "Turnbull":
+        elif method == "turnbull":
             tb = TurnbullEstimatorLifelines(l_limits, r_limits)
             event_probability = 1 - tb.predict(target_time)
         else:

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -148,7 +148,8 @@ def make_monotonic(
     seed: int
         Random seed for bootstrapping. Default: None.
     num_bs: int
-        Number of bootstrap samples. Default: None. If None, then num_bs = 10 * num_times.
+        Number of bootstrap samples. Default: None. If None, then
+        ``num_bs = max(10 * num_times, 1000)``.
     direction: {"increasing", "decreasing"}
         Required monotonic direction. Survival curves are decreasing, while
         cumulative distribution functions are increasing. Default: ``"decreasing"``.
@@ -816,41 +817,6 @@ def survival_to_quantile(
         )
 
     return qpred
-
-
-def stratified_folds_survival(
-    dataset: pd.DataFrame,
-    event_times: np.ndarray,
-    event_indicators: np.ndarray,
-    number_folds: int = 5,
-):
-    event_times, event_indicators = event_times.tolist(), event_indicators.tolist()
-    assert len(event_indicators) == len(event_times)
-
-    indicators_and_times = list(zip(event_indicators, event_times))
-    sorted_idx = [
-        i[0]
-        for i in sorted(
-            enumerate(indicators_and_times), key=lambda v: (v[1][0], v[1][1])
-        )
-    ]
-
-    folds = [
-        [sorted_idx[0]],
-        [sorted_idx[1]],
-        [sorted_idx[2]],
-        [sorted_idx[3]],
-        [sorted_idx[4]],
-    ]
-    for i in range(5, len(sorted_idx)):
-        fold_number = i % number_folds
-        folds[fold_number].append(sorted_idx[i])
-
-    training_sets = [dataset.drop(folds[i], axis=0) for i in range(number_folds)]
-    testing_sets = [dataset.iloc[folds[i], :] for i in range(number_folds)]
-
-    cross_validation_set = list(zip(training_sets, testing_sets))
-    return cross_validation_set
 
 
 def get_prob_at_zero(times: np.ndarray, survival_probabilities: np.ndarray) -> float:

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -264,18 +264,22 @@ def predict_prob_from_curve(
 ) -> float:
     """
     Predict the probability of survival at a given time point from the survival curve. The survival curve is
-    interpolated using the specified interpolation method ('Linear' or 'Pchip'). If the target time is outside the
-    range of the survival curve, the probability is extrapolated by the linear function of (0, 1) and the last time
-    point.
+    interpolated using the specified interpolation method ('Linear' or 'Pchip').
+    If the input time grid does not start at 0, a time-zero point with survival
+    probability 1 is prepended before interpolation.
+    If the target time is greater than the largest time coordinate, the probability
+    is extrapolated by the linear function through (0, 1) and the last grid point.
 
     Parameters
     ----------
     survival_curve: np.ndarray
         Survival curve. 1-D array of survival probabilities.
     times_coordinate: np.ndarray
-        Time points corresponding to the survival curve. 1-D array of time points.
+        Time points corresponding to the survival curve. 1-D array of time
+        points. Values must be non-negative. If the first value is greater than
+        0, `(0, 1)` is prepended to the curve.
     target_time: float
-        Time point at which to predict the probability of survival.
+        Non-negative time point at which to predict the probability of survival.
     interpolation: str
         The monotonic cubic interpolation method. One of ['Linear', 'Pchip']. Default: 'Linear'.
         If 'Linear', use the interp1d method from scipy.interpolate.
@@ -286,6 +290,13 @@ def predict_prob_from_curve(
     predict_probability: float
         Predicted probability of survival at the target time point.
     """
+    survival_curve, times_coordinate = zero_padding(survival_curve, times_coordinate)
+    if survival_curve.ndim != 1 or times_coordinate.ndim != 1:
+        raise ValueError("survival_curve and times_coordinate must be 1-D arrays.")
+    target_time = float(target_time)
+    if target_time < 0:
+        raise ValueError("target_time must be non-negative.")
+
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 
     # predicting boundary
@@ -294,8 +305,8 @@ def predict_prob_from_curve(
     # simply calculate the slope by using the [0, 1] - [max_time, S(t|x)]
     slope = (1 - np.array(spline(max_time)).item()) / (0 - max_time)
 
-    # If the true event time is out of predicting boundary, then use the linear fit mentioned above;
-    # Else if the true event time is in the boundary, then use the spline
+    # Above the fitted time grid, use the survival tail fit described above;
+    # otherwise use the configured interpolator.
     if target_time > max_time:
         # func: y = slope * x + 1, the minimum prob should be 0
         predict_probability = max(slope * target_time + 1, 0)
@@ -313,17 +324,22 @@ def predict_multi_probs_from_curve(
 ) -> np.ndarray:
     """
     Predict the probability of survival at multiple time points from the survival curve. The survival curve is
-    interpolated using the specified interpolation method ('Linear' or 'Pchip'). If the target time is outside the
-    range of the survival curve, the probability is extrapolated by the linear function of (0, 1) and the last time.
+    interpolated using the specified interpolation method ('Linear' or 'Pchip').
+    If the input time grid does not start at 0, a time-zero point with survival
+    probability 1 is prepended before interpolation.
+    If a target time is greater than the largest time coordinate, the probability
+    is extrapolated by the linear function through (0, 1) and the last grid point.
 
     Parameters
     ----------
     survival_curve: np.ndarray
         Survival curve. 1-D array of survival probabilities.
     times_coordinate: np.ndarray
-        Time points corresponding to the survival curve. 1-D array of time points.
+        Time points corresponding to the survival curve. 1-D array of time
+        points. Values must be non-negative. If the first value is greater than
+        0, `(0, 1)` is prepended to the curve.
     target_times: NumericArrayLike
-        Time points at which to predict the probability of survival.
+        Non-negative time points at which to predict the probability of survival.
     interpolation: str
         The monotonic cubic interpolation method. One of ['Linear', 'Pchip']. Default: 'Linear'.
         If 'Linear', use the interp1d method from scipy.interpolate.
@@ -334,7 +350,15 @@ def predict_multi_probs_from_curve(
     predict_probabilities: np.ndarray
         Predicted probabilities of survival at the target time points.
     """
-    target_times = check_and_convert(target_times).astype(float).tolist()
+    survival_curve, times_coordinate = zero_padding(survival_curve, times_coordinate)
+    if survival_curve.ndim != 1 or times_coordinate.ndim != 1:
+        raise ValueError("survival_curve and times_coordinate must be 1-D arrays.")
+    target_times = check_and_convert(target_times).astype(float)
+    if target_times.ndim != 1:
+        raise ValueError("target_times must be a 1-D array.")
+    if np.any(target_times < 0):
+        raise ValueError("target_times must be non-negative.")
+    target_times = target_times.tolist()
 
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 
@@ -344,8 +368,8 @@ def predict_multi_probs_from_curve(
     # simply calculate the slope by using the [0, 1] - [maxtime, S(t|x)]
     slope = (1 - np.array(spline(max_time)).item()) / (0 - max_time)
 
-    # If the true event time is out of predicting boundary, then use the linear fit mentioned above;
-    # Else if the true event time is in the boundary, then use the spline
+    # Above the fitted time grid, use the survival tail fit described above;
+    # otherwise use the configured interpolator.
     predict_probabilities = np.array(spline(target_times))
     for i, target_time in enumerate(target_times):
         if target_time > max_time:
@@ -850,7 +874,106 @@ def get_prob_at_zero(times: np.ndarray, survival_probabilities: np.ndarray) -> f
     return probability
 
 
-def zero_padding(pred_survs, time_coordinates):
+def _prepend_origin(
+    pred_survs: np.ndarray, 
+    time_coordinates: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Prepend survival probability 1 and time 0 while preserving input ranks.
+
+    Supports the shape combinations accepted by `zero_padding`: a shared 1-D
+    curve or 2-D sample-by-time curves, paired with a 1-D shared time grid or
+    2-D sample-specific time grids.
+    """
+    # Preserve whether the survival input represents one curve or many rows.
+    if pred_survs.ndim == 1:
+        padded_survs = np.concatenate(([1.0], pred_survs))
+    elif pred_survs.ndim == 2:
+        padded_survs = np.concatenate(
+            (np.ones((pred_survs.shape[0], 1)), pred_survs), axis=1
+        )
+    else:
+        error = "Predicted survival curves must be a 1D or 2D array, got {} instead".format(
+            pred_survs.ndim
+        )
+        raise TypeError(error)
+
+    # Preserve whether time coordinates are shared or sample-specific.
+    if time_coordinates.ndim == 1:
+        padded_times = np.concatenate(([0.0], time_coordinates))
+    elif time_coordinates.ndim == 2:
+        padded_times = np.concatenate(
+            (np.zeros((time_coordinates.shape[0], 1)), time_coordinates), axis=1
+        )
+    else:
+        error = "Time coordinates must be a 1D or 2D array, got {} instead".format(
+            time_coordinates.ndim
+        )
+        raise TypeError(error)
+
+    return padded_survs, padded_times
+
+
+def zero_padding(
+    pred_survs: np.ndarray, 
+    time_coordinates: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Prepend a time-zero survival anchor when a curve grid does not start at 0.
+
+    This helper normalizes survival curve grids to include the conventional
+    origin point ``(time=0, survival=1)``. When the first time coordinate is
+    already 0, the original arrays are returned unchanged. When the grid starts
+    elsewhere, the function prepends 0 to ``time_coordinates`` and 1 to
+    ``pred_survs`` while preserving each input's dimensionality. For 2-D time
+    grids, all rows must either already start at 0 or all require padding.
+
+    Parameters
+    ----------
+    pred_survs: np.ndarray, shape = (n_time_points,) or (n_samples, n_time_points)
+        Predicted survival probabilities. A 1-D array represents a single
+        curve or a shared curve, while a 2-D array represents one curve per
+        sample.
+    time_coordinates: np.ndarray, shape = (n_time_points,) or (n_samples, n_time_points)
+        Time coordinates corresponding to ``pred_survs``. A 1-D array is a
+        shared time grid, while a 2-D array contains sample-specific time
+        grids. Values must be non-negative, and the last dimension must have
+        the same length as
+        ``pred_survs``.
+
+    Returns
+    -------
+    padded_survs: np.ndarray
+        Survival probabilities with an origin point prepended when needed. The
+        dimensionality of ``pred_survs`` is preserved.
+    padded_times: np.ndarray
+        Time coordinates with 0 prepended when needed. The dimensionality of
+        ``time_coordinates`` is preserved.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a numeric numpy array, or if either input is
+        not a 1-D or 2-D array.
+    ValueError
+        If the inputs are empty, have different numbers of time points, contain
+        negative time coordinates, or if a 2-D time grid mixes rows that start
+        at 0 with rows that require padding.
+
+    Warns
+    -----
+    UserWarning
+        If an origin point is prepended.
+    """
+    if not isinstance(pred_survs, np.ndarray):
+        raise TypeError("pred_survs must be a numpy array.")
+    if not isinstance(time_coordinates, np.ndarray):
+        raise TypeError("time_coordinates must be a numpy array.")
+    if not np.issubdtype(pred_survs.dtype, np.number):
+        raise TypeError("pred_survs must contain numeric values.")
+    if not np.issubdtype(time_coordinates.dtype, np.number):
+        raise TypeError("time_coordinates must contain numeric values.")
+
     ndim_time = time_coordinates.ndim
     ndim_surv = pred_survs.ndim
     zero_pad_msg = (
@@ -858,69 +981,44 @@ def zero_padding(pred_survs, time_coordinates):
         "with 100% survival probability. Adding 0 to the beginning of the time coordinates "
         "and 1 to the beginning of the predicted curves."
     )
-    if ndim_time == 1:
-        assert ndim_surv == 2, (
-            "Either predicted_survival_curves or time_coordinates "
-            "must be a 2D array, got {} and {}".format(ndim_surv, ndim_time)
+
+    if ndim_surv not in (1, 2):
+        error = "Predicted survival curves must be a 1D or 2D array, got {} instead".format(
+            ndim_surv
         )
-        if time_coordinates[0] != 0:
-            warnings.warn(zero_pad_msg)
-            _pred_survs = np.empty((pred_survs.shape[0], pred_survs.shape[1] + 1))
-            _pred_survs[:, 1:] = pred_survs
-            _pred_survs[:, 0] = 1.0
-            _time_coordinates = np.empty(time_coordinates.shape[0] + 1)
-            _time_coordinates[1:] = time_coordinates
-            _time_coordinates[0] = 0
-        else:
-            _pred_survs = pred_survs
-            _time_coordinates = time_coordinates
-    elif ndim_time == 2:
+        raise TypeError(error)
+    if ndim_time not in (1, 2):
+        error = "Time coordinates must be a 1D or 2D array, got {} instead".format(
+            ndim_time
+        )
+        raise TypeError(error)
+    if pred_survs.shape[-1] == 0 or time_coordinates.shape[-1] == 0:
+        raise ValueError("pred_survs and time_coordinates must be non-empty.")
+    if pred_survs.shape[-1] != time_coordinates.shape[-1]:
+        raise ValueError(
+            "Predicted survival curves and time coordinates must have "
+            "the same number of time points."
+        )
+    if np.any(time_coordinates < 0):
+        raise ValueError("time_coordinates must be non-negative.")
+
+    if ndim_time == 1:
+        needs_padding = not np.isclose(time_coordinates[0], 0.0)
+    else:
         starts_at_zero = np.isclose(time_coordinates[:, 0], 0.0)
         if np.any(starts_at_zero) and not np.all(starts_at_zero):
             raise ValueError(
                 "All rows of 2D time_coordinates must either start at 0 or "
                 "all require zero-padding."
             )
-
         needs_padding = not np.all(starts_at_zero)
-        if ndim_surv == 1:
-            if needs_padding:
-                warnings.warn(zero_pad_msg)
-                _pred_survs = np.empty(pred_survs.shape[0] + 1)
-                _pred_survs[1:] = pred_survs
-                _pred_survs[0] = 1.0
-                _time_coordinates = np.empty(
-                    (time_coordinates.shape[0], time_coordinates.shape[1] + 1)
-                )
-                _time_coordinates[:, 1:] = time_coordinates
-                _time_coordinates[:, 0] = 0
-            else:
-                _pred_survs = pred_survs
-                _time_coordinates = time_coordinates
-        elif ndim_surv == 2:
-            if needs_padding:
-                warnings.warn(zero_pad_msg)
-                _pred_survs = np.empty((pred_survs.shape[0], pred_survs.shape[1] + 1))
-                _pred_survs[:, 1:] = pred_survs
-                _pred_survs[:, 0] = 1.0
-                _time_coordinates = np.empty(
-                    (time_coordinates.shape[0], time_coordinates.shape[1] + 1)
-                )
-                _time_coordinates[:, 1:] = time_coordinates
-                _time_coordinates[:, 0] = 0.0
-            else:
-                _pred_survs = pred_survs
-                _time_coordinates = time_coordinates
-        else:
-            error = "Predicted survival curves must be a 1D or 2D array, got {} instead".format(
-                ndim_surv
-            )
-            raise TypeError(error)
+
+    if needs_padding:
+        warnings.warn(zero_pad_msg)
+        _pred_survs, _time_coordinates = _prepend_origin(pred_survs, time_coordinates)
     else:
-        error = "Time coordinates must be a 1D or 2D array, got {} instead".format(
-            ndim_time
-        )
-        raise TypeError(error)
+        _pred_survs = pred_survs
+        _time_coordinates = time_coordinates
 
     return _pred_survs, _time_coordinates
 

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -362,7 +362,6 @@ def predict_multi_probs_from_curve(
         raise ValueError("target_times must be a 1-D array.")
     if np.any(target_times < 0):
         raise ValueError("target_times must be non-negative.")
-    target_times = target_times.tolist()
 
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 
@@ -375,9 +374,10 @@ def predict_multi_probs_from_curve(
     # Above the fitted time grid, use the survival tail fit described above;
     # otherwise use the configured interpolator.
     predict_probabilities = np.array(spline(target_times))
-    for i, target_time in enumerate(target_times):
-        if target_time > max_time:
-            predict_probabilities[i] = max(slope * target_time + 1, 0)
+    after_grid = target_times > max_time
+    predict_probabilities[after_grid] = np.maximum(
+        slope * target_times[after_grid] + 1, 0
+    )
 
     return predict_probabilities
 

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -110,9 +110,12 @@ def check_monotonicity(
     if array.ndim not in (1, 2):
         raise ValueError("The input array must be 1-D or 2-D.")
 
-    differences = np.diff(array, axis=-1)
-    is_increasing = bool(np.all(differences >= 0))
-    is_decreasing = bool(np.all(differences <= 0))
+    # Direct adjacent comparisons handle repeated infinities; np.diff would
+    # turn inf - inf into nan and falsely reject monotonic arrays.
+    adjacent_left = array[..., :-1]
+    adjacent_right = array[..., 1:]
+    is_increasing = bool(np.all(adjacent_right >= adjacent_left))
+    is_decreasing = bool(np.all(adjacent_right <= adjacent_left))
 
     if direction is None:
         return is_increasing or is_decreasing
@@ -776,6 +779,13 @@ def survival_to_quantile(
         # Build monotone x for interpolator: unique CDF values (keep first)
         cdf_i_unique, keep_idx = np.unique(cdf_i, return_index=True)
         t_i_unique = t_i[keep_idx]
+        max_cdf = cdf_i_unique[-1]
+
+        if max_cdf <= 0:
+            # No observed CDF increase: F(t)=0 on the supplied grid, so only
+            # q=0 is reached at the origin; positive quantiles are undefined.
+            qpred[i, :] = np.where(quantile_levels == 0.0, 0.0, np.inf)
+            continue
 
         # If the first CDF value is >0, prepend (0, 0) to allow interpolation near q≈0
         if cdf_i_unique[0] > 0.0:
@@ -799,14 +809,9 @@ def survival_to_quantile(
         # Interpolate for all qs, then handle tail beyond observed max CDF
         qpred[i, :] = interp(quantile_levels)
 
-        max_cdf = cdf_i_unique[-1]
-        if max_cdf <= 0:
-            # degenerate case: no events observed; fall back to linear tail from origin
-            qpred[i, :] = quantile_levels / slope[i]
-        else:
-            beyond = np.where(quantile_levels > max_cdf)[0]
-            if beyond.size > 0:
-                qpred[i, beyond] = quantile_levels[beyond] / slope[i]
+        beyond = np.where(quantile_levels > max_cdf)[0]
+        if beyond.size > 0:
+            qpred[i, beyond] = quantile_levels[beyond] / slope[i]
 
     # Sanity checks
     if np.any(qpred < 0):

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -119,6 +119,7 @@ def check_monotonicity(
 
     if direction is None:
         return is_increasing or is_decreasing
+    direction = direction.lower()
     if direction == "increasing":
         return is_increasing
     if direction == "decreasing":
@@ -162,6 +163,9 @@ def make_monotonic(
     survival_curves: np.ndarray
         Monotonic probability curves with the same dimensionality as the input.
     """
+    method = method.lower()
+    direction = direction.lower()
+
     valid_methods = {"ceil", "floor", "bootstrap", "isotonic"}
     if method not in valid_methods:
         raise ValueError(
@@ -249,11 +253,12 @@ def make_monotonic(
 def interpolated_curve(
     times_coordinate: np.ndarray, curve: np.ndarray, interpolation: str = "Linear"
 ) -> Union[interp1d, PchipInterpolator]:
-    if interpolation == "Linear":
+    interpolation = interpolation.lower()
+    if interpolation == "linear":
         spline = interp1d(
             times_coordinate, curve, kind="linear", fill_value="extrapolate"
         )
-    elif interpolation == "Pchip":
+    elif interpolation == "pchip":
         spline = PchipInterpolator(times_coordinate, curve)
     else:
         raise ValueError("interpolation must be one of ['Linear', 'Pchip']")
@@ -482,13 +487,14 @@ def predict_rmst(
         survival_curves, times_coordinates
     )
 
-    if interpolation == "None":
+    interpolation = interpolation.lower()
+    if interpolation == "none":
         width = np.diff(time_grids, axis=1)
         areas = width * curves[:, :-1]
         rmst = np.sum(areas, axis=1)
-    elif interpolation == "Linear":
+    elif interpolation == "linear":
         rmst = trapezoid(curves, time_grids, axis=1)
-    elif interpolation == "Pchip":
+    elif interpolation == "pchip":
         rmst = np.empty(curves.shape[0])
         for i in range(curves.shape[0]):
             spline = PchipInterpolator(time_grids[i], curves[i])
@@ -632,6 +638,8 @@ def predict_median_st_ind(
 
     min_prob = min(survival_curve)
 
+    interpolation = interpolation.lower()
+
     if min_prob <= 0.5:
         idx_arr = np.where(survival_curve <= 0.5)[0]
 
@@ -643,14 +651,14 @@ def predict_median_st_ind(
                 times_coordinate[idx_after_median - 1],
                 times_coordinate[idx_after_median],
             )
-            if interpolation == "Linear":
+            if interpolation == "linear":
                 # linear interpolation to find the median time
                 p1, p2 = (
                     survival_curve[idx_after_median - 1],
                     survival_curve[idx_after_median],
                 )
                 median_st = t1 + (0.5 - p1) * (t2 - t1) / (p2 - p1)
-            elif interpolation == "Pchip":
+            elif interpolation == "pchip":
                 # reverse the array because the PchipInterpolator requires the x to be strictly increasing
                 spline = interpolated_curve(
                     times_coordinate, survival_curve, interpolation
@@ -755,9 +763,10 @@ def survival_to_quantile(
     if np.any(quantile_levels < 0) or np.any(quantile_levels >= 1):
         raise ValueError("`quantile_levels` must be in [0, 1).")
 
-    if interpolate == "Linear":
+    interpolate = interpolate.lower()
+    if interpolate == "linear":
         Interpolator = interp1d
-    elif interpolate == "Pchip":
+    elif interpolate == "pchip":
         Interpolator = PchipInterpolator
     else:
         raise ValueError(f"Unknown interpolation method: {interpolate}")

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -153,29 +153,18 @@ class SurvivalEvaluator:
 
     def set_prediction_inputs(
         self,
-        pred_survs: Optional[NumericArrayLike] = None,
-        time_coordinates: Optional[NumericArrayLike] = None,
+        pred_survs: NumericArrayLike,
+        time_coordinates: NumericArrayLike,
     ):
         """
-        Reset predicted survival curves and/or their time coordinates.
+        Reset predicted survival curves and their time coordinates together.
 
         Prefer this method when updating both inputs together, because the
         pair is validated, zero-padded, and cached-property invalidated once.
         Property setters remain available for changing only one input.
         """
-        if pred_survs is None and time_coordinates is None:
-            raise ValueError(
-                "Please provide at least one of 'pred_survs' or 'time_coordinates'."
-            )
-
-        pred_survs = (
-            self._pred_survs if pred_survs is None else check_and_convert(pred_survs)
-        )
-        time_coordinates = (
-            self._time_coordinates
-            if time_coordinates is None
-            else check_and_convert(time_coordinates)
-        )
+        pred_survs = check_and_convert(pred_survs)
+        time_coordinates = check_and_convert(time_coordinates)
 
         ndim_surv = pred_survs.ndim
         ndim_time = time_coordinates.ndim
@@ -201,7 +190,18 @@ class SurvivalEvaluator:
     @pred_survs.setter
     def pred_survs(self, val: NumericArrayLike):
         print("Setter called. Resetting predicted curves for this evaluator.")
-        self.set_prediction_inputs(pred_survs=val)
+        pred_survs = check_and_convert(val)
+        # The stored grid may already include a zero-time column inserted by
+        # zero_padding. Accept raw replacement curves by adding the matching
+        # survival-at-zero column before validating curve/grid lengths.
+        if (
+            self._time_coordinates.shape[-1] == pred_survs.shape[-1] + 1
+            and np.all(np.isclose(self._time_coordinates[..., 0], 0.0))
+        ):
+            pred_survs = np.concatenate(
+                (np.ones((*pred_survs.shape[:-1], 1)), pred_survs), axis=-1
+            )
+        self.set_prediction_inputs(pred_survs, self._time_coordinates)
 
     @property
     def time_coordinates(self):
@@ -210,7 +210,19 @@ class SurvivalEvaluator:
     @time_coordinates.setter
     def time_coordinates(self, val: NumericArrayLike):
         print("Setter called. Resetting time coordinates for this evaluator.")
-        self.set_prediction_inputs(time_coordinates=val)
+        time_coordinates = check_and_convert(val)
+        # Symmetric one-sided update: if curves are already zero-padded and
+        # the replacement grid is raw, prepend time zero so the pair remains
+        # aligned before the shared validation path runs.
+        if (
+            self._pred_survs.shape[-1] == time_coordinates.shape[-1] + 1
+            and not np.all(np.isclose(time_coordinates[..., 0], 0.0))
+        ):
+            time_coordinates = np.concatenate(
+                (np.zeros((*time_coordinates.shape[:-1], 1)), time_coordinates),
+                axis=-1,
+            )
+        self.set_prediction_inputs(self._pred_survs, time_coordinates)
 
     @cached_property
     def predicted_event_times(self):

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -96,11 +96,15 @@ class SurvivalEvaluator:
                 "At least one of 'pred_survs' or 'time_coordinates' must be a 2D array."
             )
 
+        event_times, event_indicators = check_and_convert(event_times, event_indicators)
+        self._validate_prediction_sample_count(
+            pred_survs, time_coordinates, event_times.shape[0]
+        )
+
         self._pred_survs, self._time_coordinates = zero_padding(
             pred_survs, time_coordinates
         )
 
-        event_times, event_indicators = check_and_convert(event_times, event_indicators)
         self.event_times = event_times
         self.event_indicators = event_indicators
 
@@ -131,6 +135,30 @@ class SurvivalEvaluator:
             raise TypeError(
                 "Train set information is missing. "
                 "Evaluator cannot perform {} evaluation.".format(method_name)
+            )
+
+    @staticmethod
+    def _validate_prediction_sample_count(
+        pred_survs: np.ndarray,
+        time_coordinates: np.ndarray,
+        n_samples: int,
+    ):
+        sample_counts = {}
+        if pred_survs.ndim == 2:
+            sample_counts["pred_survs"] = pred_survs.shape[0]
+        if time_coordinates.ndim == 2:
+            sample_counts["time_coordinates"] = time_coordinates.shape[0]
+
+        mismatched_counts = {
+            name: count for name, count in sample_counts.items() if count != n_samples
+        }
+        if mismatched_counts:
+            count_details = ", ".join(
+                f"{name} has {count}" for name, count in mismatched_counts.items()
+            )
+            raise ValueError(
+                "The number of prediction rows must match the number of testing "
+                f"samples ({n_samples}); {count_details}."
             )
 
     @property

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -684,12 +684,15 @@ class SurvivalEvaluator:
 
         Parameters
         ----------
-        target_times: np.ndarray, default: None
+        target_times: np.ndarray
             The specific time points for which to estimate the Brier scores.
         IPCW_weighted: bool, default = True
             Whether to use IPCW weighting for the Brier score.
-        :return:
-            Values of multiple Brier scores.
+
+        Returns
+        -------
+        brier_scores: np.ndarray
+            Values of multiple Brier scores, in the same order as `target_times`.
         """
         # Check if there is no censored instance, if so, naive Brier score is applied
         if self._NO_CENSOR:

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -86,27 +86,12 @@ class SurvivalEvaluator:
         interpolation: str, default = "Linear"
             Method for interpolation. Available options are ['Linear', 'Pchip'].
         """
-        pred_survs = check_and_convert(pred_survs)
-        time_coordinates = check_and_convert(time_coordinates)
-
-        self.ndim_time = time_coordinates.ndim
-        self.ndim_surv = pred_survs.ndim
-        if self.ndim_time == 1 and self.ndim_surv == 1:
-            raise TypeError(
-                "At least one of 'pred_survs' or 'time_coordinates' must be a 2D array."
-            )
-
         event_times, event_indicators = check_and_convert(event_times, event_indicators)
-        self._validate_prediction_sample_count(
-            pred_survs, time_coordinates, event_times.shape[0]
-        )
-
-        self._pred_survs, self._time_coordinates = zero_padding(
-            pred_survs, time_coordinates
-        )
-
         self.event_times = event_times
         self.event_indicators = event_indicators
+        self.set_prediction_inputs(
+            pred_survs=pred_survs, time_coordinates=time_coordinates
+        )
 
         if (train_event_times is not None) and (train_event_indicators is not None):
             train_event_times, train_event_indicators = check_and_convert(
@@ -161,6 +146,54 @@ class SurvivalEvaluator:
                 f"samples ({n_samples}); {count_details}."
             )
 
+    def _testing_sample_count(self) -> int:
+        if hasattr(self, "left_limits"):
+            return self.left_limits.shape[0]
+        return self.event_times.shape[0]
+
+    def set_prediction_inputs(
+        self,
+        pred_survs: Optional[NumericArrayLike] = None,
+        time_coordinates: Optional[NumericArrayLike] = None,
+    ):
+        """
+        Reset predicted survival curves and/or their time coordinates.
+
+        Prefer this method when updating both inputs together, because the
+        pair is validated, zero-padded, and cached-property invalidated once.
+        Property setters remain available for changing only one input.
+        """
+        if pred_survs is None and time_coordinates is None:
+            raise ValueError(
+                "Please provide at least one of 'pred_survs' or 'time_coordinates'."
+            )
+
+        pred_survs = (
+            self._pred_survs if pred_survs is None else check_and_convert(pred_survs)
+        )
+        time_coordinates = (
+            self._time_coordinates
+            if time_coordinates is None
+            else check_and_convert(time_coordinates)
+        )
+
+        ndim_surv = pred_survs.ndim
+        ndim_time = time_coordinates.ndim
+        if ndim_time == 1 and ndim_surv == 1:
+            raise TypeError(
+                "At least one of 'pred_survs' or 'time_coordinates' must be a 2D array."
+            )
+
+        self._validate_prediction_sample_count(
+            pred_survs, time_coordinates, self._testing_sample_count()
+        )
+        self._pred_survs, self._time_coordinates = zero_padding(
+            pred_survs, time_coordinates
+        )
+        self.ndim_surv = self._pred_survs.ndim
+        self.ndim_time = self._time_coordinates.ndim
+        self._clear_cache()
+
     @property
     def pred_survs(self):
         return self._pred_survs
@@ -168,8 +201,7 @@ class SurvivalEvaluator:
     @pred_survs.setter
     def pred_survs(self, val: NumericArrayLike):
         print("Setter called. Resetting predicted curves for this evaluator.")
-        self._pred_survs = check_and_convert(val)
-        self._clear_cache()
+        self.set_prediction_inputs(pred_survs=val)
 
     @property
     def time_coordinates(self):
@@ -178,8 +210,7 @@ class SurvivalEvaluator:
     @time_coordinates.setter
     def time_coordinates(self, val: NumericArrayLike):
         print("Setter called. Resetting time coordinates for this evaluator.")
-        self._time_coordinates = check_and_convert(val)
-        self._clear_cache()
+        self.set_prediction_inputs(time_coordinates=val)
 
     @cached_property
     def predicted_event_times(self):

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -752,7 +752,9 @@ class SurvivalEvaluator:
         Returns
         -------
         ibs: float
-            The integrated Brier score.
+            The integrated Brier score when `draw_figure` is False.
+        result: tuple[float, tuple[plt.Figure, plt.Axes]]
+            When `draw_figure` is True, returns `(ibs, (fig, ax))`.
         """
         # Check if there is no censored instance, if so, naive Brier score is applied
         if self._NO_CENSOR:

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -2216,6 +2216,7 @@ class QuantileRegEvaluator(SurvivalEvaluator):
         interpolation: str, default = "Linear"
             Method for interpolation. Available options are ['Linear', 'Pchip'].
         """
+        quantile_levels = check_and_convert(quantile_levels)
         survival_level = 1 - quantile_levels
         super(QuantileRegEvaluator, self).__init__(
             survival_level,

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -111,11 +111,12 @@ class SurvivalEvaluator:
         self.train_event_times = train_event_times
         self.train_event_indicators = train_event_indicators
 
-        if predict_time_method == "Median":
+        predict_time_method = predict_time_method.lower()
+        if predict_time_method == "median":
             self.predict_time_method = predict_median_st
-        elif predict_time_method == "Mean":
+        elif predict_time_method == "mean":
             self.predict_time_method = predict_mean_st
-        elif predict_time_method == "RMST":
+        elif predict_time_method == "rmst":
             self.predict_time_method = predict_rmst
         else:
             error = "Please enter one of 'Median', 'Mean', or 'RMST' for calculating predicted survival time."
@@ -569,10 +570,11 @@ class SurvivalEvaluator:
             The concordance index, the number of concordant pairs, and the number of total pairs.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Harrell"
+            method = "harrell"
 
-        if method == "Margin":
+        if method == "margin":
             self._error_trainset("margin concordance")
 
         return concordance(
@@ -844,6 +846,7 @@ class SurvivalEvaluator:
                 bs_dict[time_point] = b_score
             print("Brier scores for multiple time points are:\n", bs_dict)
 
+        integration_method = integration_method.lower()
         if integration_method == "trapz":
             integral_value = trapezoid(b_scores, target_times)
         elif integration_method == "simpson":
@@ -915,11 +918,12 @@ class SurvivalEvaluator:
         mae_score: float
             The MAE score for the test set.
         """
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Uncensored"
+            method = "uncensored"
 
         if weighted is None:
-            weighted = method not in ("Uncensored", "Hinge")
+            weighted = method not in ("uncensored", "hinge")
 
         return mean_error(
             predicted_times=self.predicted_event_times,
@@ -966,11 +970,12 @@ class SurvivalEvaluator:
         mse_score: float
             The MSE score for the test set.
         """
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Uncensored"
+            method = "uncensored"
 
         if weighted is None:
-            weighted = method not in ("Uncensored", "Hinge")
+            weighted = method not in ("uncensored", "hinge")
 
         return mean_error(
             predicted_times=self.predicted_event_times,
@@ -1329,11 +1334,12 @@ class SurvivalEvaluator:
         residuals: np.ndarray
             The residuals calculated from the predicted survival curve.
         """
+        method = method.lower()
         if self._NO_CENSOR:
             method = (
-                "CoxSnell"
+                "coxsnell"
                 if method
-                in ["CoxSnell", "Modified CoxSnell-v1", "Modified CoxSnell-v2"]
+                in ["coxsnell", "modified coxsnell-v1", "modified coxsnell-v2"]
                 else method
             )
 
@@ -1717,10 +1723,11 @@ class PointEvaluator:
             The total number of comparable pairs considered in the concordance calculation.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Harrell"
+            method = "harrell"
 
-        if method == "Margin":
+        if method == "margin":
             self._error_trainset("margin concordance")
 
         return concordance(
@@ -1764,11 +1771,12 @@ class PointEvaluator:
         mae_score: float
             The MAE score for the test set.
         """
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Uncensored"
+            method = "uncensored"
 
         if weighted is None:
-            weighted = method not in ("Uncensored", "Hinge")
+            weighted = method not in ("uncensored", "hinge")
 
         return mean_error(
             predicted_times=self._pred_times,
@@ -1815,11 +1823,12 @@ class PointEvaluator:
         mse_score: float
             The MSE score for the test set.
         """
+        method = method.lower()
         if self._NO_CENSOR:
-            method = "Uncensored"
+            method = "uncensored"
 
         if weighted is None:
-            weighted = method not in ("Uncensored", "Hinge")
+            weighted = method not in ("uncensored", "hinge")
 
         return mean_error(
             predicted_times=self._pred_times,

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -737,8 +737,8 @@ class SurvivalEvaluator:
         target_times : np.ndarray, shape = (m,), optional (default=None)
             Explicit time grid at which to evaluate the Brier score.
             If provided, `num_points` must be None. We'll integrate over exactly these times.
-
-            NOTE: You are responsible for making sure these are sorted ascending and lie within the support of the model.
+            If unsorted, values are sorted ascending with a warning. You are
+            responsible for making sure they lie within the support of the model.
 
         IPCW_weighted: bool, default = True
             Whether to use IPCW weighting for the Brier score.
@@ -789,7 +789,7 @@ class SurvivalEvaluator:
                     "to perform numerical integration."
                 )
 
-            # We assume caller gave sorted points. If not, sort them.
+            # Sort explicit target times if needed, preserving the integration range.
             if not np.all(np.diff(target_times) >= 0):
                 warnings.warn("`target_times` is not sorted; sorting it now.")
                 target_times = np.sort(target_times)

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -79,31 +79,16 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         interpolation: str, default: "Linear"
             Interpolation method for the survival curve. Options are "Linear" or "Pchip".
         """
-        pred_survs = check_and_convert(pred_survs)
-        time_coordinates = check_and_convert(time_coordinates)
-
-        self.ndim_time = time_coordinates.ndim
-        self.ndim_surv = pred_survs.ndim
-        if self.ndim_time == 1 and self.ndim_surv == 1:
-            raise TypeError(
-                "At least one of 'pred_survs' or 'time_coordinates' must be a 2D array."
-            )
-
         left_limits, right_limits = check_and_convert(left_limits, right_limits)
-        self._validate_prediction_sample_count(
-            pred_survs, time_coordinates, left_limits.shape[0]
-        )
-
-        self._pred_survs, self._time_coordinates = zero_padding(
-            pred_survs, time_coordinates
-        )
-
         if np.any(~np.isfinite(left_limits)) or np.any(left_limits < 0):
             raise ValueError("Testing left limits must be finite and non-negative.")
         if np.any(left_limits > right_limits):
             raise ValueError("Found an interval with left > right in the testing data.")
         self.left_limits = left_limits
         self.right_limits = right_limits
+        self.set_prediction_inputs(
+            pred_survs=pred_survs, time_coordinates=time_coordinates
+        )
 
         if (train_left_limits is not None) and (train_right_limits is not None):
             train_left_limits, train_right_limits = check_and_convert(

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -332,8 +332,8 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             across train + test.
 
             If both `num_points` and `target_times` are None:
-            - We try to infer `target_times` from the unique censoring times in the *test* set.
-            (This matches your old behavior.)
+            - We infer `target_times` from the unique finite left and right interval
+              endpoints in the test set.
 
         target_times : np.ndarray, shape = (m,), optional (default=None)
             Explicit time grid at which to evaluate the Brier score.
@@ -444,7 +444,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             target_times = np.linspace(0.0, max_target_time, num_points)
             time_range = max_target_time  # because we started at 0
 
-        # Case 3: neither provided → infer from the left/right limits of censored test samples, excluding infs
+        # Case 3: neither provided -> infer from finite test interval endpoints.
         else:
             target_times = np.unique(
                 np.concatenate(
@@ -456,7 +456,6 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             )
 
             if target_times.size < 2:
-                # (old behavior raised if no censor data at all)
                 raise ValueError(
                     "Could not infer `target_times` from testing samples "
                     "(e.g., no/too-few test points). "
@@ -524,8 +523,8 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             across train + test.
 
             If both `num_points` and `target_times` are None:
-            - We try to infer `target_times` from the unique censoring times in the *test* set.
-            (This matches your old behavior.)
+            - We infer `target_times` from the unique finite left and right interval
+              endpoints in the test set.
 
         target_times : np.ndarray, shape = (m,), optional (default=None)
             Explicit time grid at which to evaluate the Brier score.

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -89,11 +89,15 @@ class IntervalCenEvaluator(SurvivalEvaluator):
                 "At least one of 'pred_survs' or 'time_coordinates' must be a 2D array."
             )
 
+        left_limits, right_limits = check_and_convert(left_limits, right_limits)
+        self._validate_prediction_sample_count(
+            pred_survs, time_coordinates, left_limits.shape[0]
+        )
+
         self._pred_survs, self._time_coordinates = zero_padding(
             pred_survs, time_coordinates
         )
 
-        left_limits, right_limits = check_and_convert(left_limits, right_limits)
         if np.any(~np.isfinite(left_limits)) or np.any(left_limits < 0):
             raise ValueError("Testing left limits must be finite and non-negative.")
         if np.any(left_limits > right_limits):

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -116,11 +116,12 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         self.train_left_limits = train_left_limits
         self.train_right_limits = train_right_limits
 
-        if predict_time_method == "Median":
+        predict_time_method = predict_time_method.lower()
+        if predict_time_method == "median":
             self.predict_time_method = predict_median_st
-        elif predict_time_method == "Mean":
+        elif predict_time_method == "mean":
             self.predict_time_method = predict_mean_st
-        elif predict_time_method == "RMST":
+        elif predict_time_method == "rmst":
             self.predict_time_method = predict_rmst
         else:
             error = "Please enter one of 'Median', 'Mean', or 'RMST' for calculating predicted survival time."
@@ -174,11 +175,14 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         pred_times = self.predict_time_method(
             self._pred_survs, self._time_coordinates, interpolation=self.interpolation
         )
+        method = method.lower()
+        ties = ties.lower()
+
         if method == "midpoint":
             imp_times, imp_indicators = impute_times_midpoint(
                 self.left_limits, self.right_limits
             )
-            ties = "None" if ties == "skip" else "Risk"
+            ties = "none" if ties == "skip" else "risk"
             c_index, num, den = concordance(
                 predicted_times=pred_times,
                 event_times=imp_times,
@@ -232,12 +236,13 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             The Brier score at the given time point.
         """
         # Check if there is no censored instance, if so, naive Brier score is applied
+        method = method.lower()
         if self._NO_CENSOR:
             method = "uncensored"
 
-        if method in ["Tsouprou-conditional", "Tsouprou-marginal"]:
+        if method in ["tsouprou-conditional", "tsouprou-marginal"]:
             self._error_trainset("Tsouprou Brier score")
-            if method == "Tsouprou-conditional":
+            if method == "tsouprou-conditional":
                 if x is None or x_train is None:
                     raise TypeError(
                         "x and x_train must be provided for Tsouprou-conditional method."
@@ -284,12 +289,13 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         x_train: Optional[np.ndarray] = None,
     ):
         # Check if there is no censored instance, if so, naive Brier score is applied
+        method = method.lower()
         if self._NO_CENSOR:
             method = "uncensored"
 
-        if method in ["Tsouprou-conditional", "Tsouprou-marginal"]:
+        if method in ["tsouprou-conditional", "tsouprou-marginal"]:
             self._error_trainset("Tsouprou Brier score")
-            if method == "Tsouprou-conditional":
+            if method == "tsouprou-conditional":
                 if x is None or x_train is None:
                     raise TypeError(
                         "x and x_train must be provided for Tsouprou-conditional method."
@@ -365,12 +371,13 @@ class IntervalCenEvaluator(SurvivalEvaluator):
             When `draw_figure` is True, returns `(ibs, (fig, ax))`.
         """
         # Check if there is no censored instance, if so, naive method is applied
+        method = method.lower()
         if self._NO_CENSOR:
             method = "uncensored"
 
-        if method in ["Tsouprou-conditional", "Tsouprou-marginal"]:
+        if method in ["tsouprou-conditional", "tsouprou-marginal"]:
             self._error_trainset("Tsouprou IBS")
-            if method == "Tsouprou-conditional":
+            if method == "tsouprou-conditional":
                 if x is None or x_train is None:
                     raise TypeError(
                         "x and x_train must be provided for Tsouprou-conditional method."
@@ -475,6 +482,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
                 bs_dict[time_point] = b_score
             print("Brier scores for multiple time points are:\n", bs_dict)
 
+        integration_method = integration_method.lower()
         if integration_method == "trapz":
             integral_value = trapezoid(b_scores, target_times)
         elif integration_method == "simpson":

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -338,8 +338,8 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         target_times : np.ndarray, shape = (m,), optional (default=None)
             Explicit time grid at which to evaluate the Brier score.
             If provided, `num_points` must be None. We'll integrate over exactly these times.
-
-            NOTE: You are responsible for making sure these are sorted ascending and lie within the support of the model.
+            If unsorted, values are sorted ascending with a warning. You are
+            responsible for making sure they lie within the support of the model.
 
         method: str, default: "uncensored"
             The method to use for calculating the Brier score. Options are "uncensored", "Tsouprou-conditional", and "Tsouprou-marginal".
@@ -423,7 +423,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
                     "to perform numerical integration."
                 )
 
-            # We assume caller gave sorted points. If not, sort them.
+            # Sort explicit target times if needed, preserving the integration range.
             if not np.all(np.diff(target_times) >= 0):
                 warnings.warn("`target_times` is not sorted; sorting it now.")
                 target_times = np.sort(target_times)
@@ -529,8 +529,8 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         target_times : np.ndarray, shape = (m,), optional (default=None)
             Explicit time grid at which to evaluate the Brier score.
             If provided, `num_points` must be None. We'll integrate over exactly these times.
-
-            NOTE: You are responsible for making sure these are sorted ascending and lie within the support of the model.
+            If unsorted, values are sorted ascending with a warning. You are
+            responsible for making sure they lie within the support of the model.
 
         Returns
         -------

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -360,11 +360,9 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         Returns
         -------
         ibs: float
-            The Integrated Brier Score.
-        figure: plt.Figure
-            The figure object containing the Brier score curve.
-        axes: plt.Axes
-            The axes object containing the Brier score curve.
+            The Integrated Brier Score when `draw_figure` is False.
+        result: tuple[float, tuple[plt.Figure, plt.Axes]]
+            When `draw_figure` is True, returns `(ibs, (fig, ax))`.
         """
         # Check if there is no censored instance, if so, naive method is applied
         if self._NO_CENSOR:

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/CopulaGraphic.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/CopulaGraphic.py
@@ -60,18 +60,19 @@ class CopulaGraphic:
         ]
 
         event_diff = self.population_count - self.events
+        type = type.lower()
 
         with np.errstate(divide="ignore"):
             # ignore division by zero warnings,
             # such warnings are expected when the last time point has an event so the event_diff is 0.
             # but we will set the last point to 0 anyway.
-            if type == "Clayton":
+            if type == "clayton":
                 diff_ = (event_diff / self.n_samples) ** (-alpha) - (
                     self.population_count / self.n_samples
                 ) ** (-alpha)
                 diff_[-1] = 0
                 self.survival_probabilities = (1.0 + np.cumsum(diff_)) ** (-1.0 / alpha)
-            elif type == "Gumbel":
+            elif type == "gumbel":
                 diff_ = (-np.log(event_diff / self.n_samples)) ** (alpha + 1) - (
                     -np.log(self.population_count / self.n_samples)
                 ) ** (alpha + 1)
@@ -79,7 +80,7 @@ class CopulaGraphic:
                 self.survival_probabilities = np.exp(
                     -np.cumsum(diff_) ** (1 / (1 + alpha))
                 )
-            elif type == "Frank":
+            elif type == "frank":
                 log_diff_ = np.log(
                     (np.exp(-alpha * event_diff / self.n_samples) - 1)
                     / (np.exp(-alpha * self.population_count / self.n_samples) - 1)

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/Fiducial.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/Fiducial.py
@@ -210,6 +210,7 @@ def _linear_interpolation_qp(
     q[-1] = -lam * wEnd
 
     # Try OSQP first, fall back to scipy on failure
+    solver = solver.lower()
     if solver == "osqp":
         return _solve_qp_osqp(Q, q, fid_lower, fid_upper, osqp_solver)
     else:

--- a/SurvivalEVAL/version.py
+++ b/SurvivalEVAL/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/examples/Calibration_for_CrossValidation_Example.ipynb
+++ b/examples/Calibration_for_CrossValidation_Example.ipynb
@@ -86,9 +86,9 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "from sklearn.model_selection import StratifiedKFold\n",
     "\n",
-    "from SurvivalEVAL import LifelinesEvaluator\n",
-    "from SurvivalEVAL.Evaluations.util import stratified_folds_survival"
+    "from SurvivalEVAL import LifelinesEvaluator"
    ]
   },
   {
@@ -182,7 +182,10 @@
     "total_durations = np.empty([0, ])\n",
     "total_events = np.empty([0, ])\n",
     "\n",
-    "for data_train, data_test in tqdm(stratified_folds_survival(rossi, rossi.week.values, rossi.arrest.values)):\n",
+    "cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)\n",
+    "for train_idx, test_idx in tqdm(cv.split(rossi, rossi['arrest'])):\n",
+    "    data_train = rossi.iloc[train_idx]\n",
+    "    data_test = rossi.iloc[test_idx]\n",
     "    durations_test = data_test['week'].values\n",
     "    events_test = data_test['arrest'].values.astype('bool')\n",
     "    # Fit the model\n",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     python_requires=">=3.9",
     keywords="survival analysis, evaluation, metrics, survivaleval",
-    license="MIT",
+    license="GPLv3",
     install_requires=read("requirements.txt").splitlines(),
 )
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -427,3 +427,51 @@ def test_pred_survs_setter_resets_cache(evaluator_data):
     evaluator.pred_survs = updated_curves
     refreshed_times = evaluator.predicted_event_times
     assert not np.allclose(refreshed_times, original_times)
+
+
+def test_time_coordinates_setter_refreshes_dimension_metadata(evaluator_data):
+    evaluator = evaluator_data["evaluator"]
+    per_sample_grid = np.tile(
+        evaluator.time_coordinates, (evaluator_data["n_test"], 1)
+    )
+
+    evaluator.time_coordinates = per_sample_grid
+
+    assert evaluator.ndim_time == 2
+    assert evaluator.predict_probability_from_curve(8.0).shape == (
+        evaluator_data["n_test"],
+    )
+
+
+def test_pred_survs_setter_rejects_prediction_row_count_mismatch(evaluator_data):
+    evaluator = evaluator_data["evaluator"]
+    bad_curves = np.ones(
+        (evaluator_data["n_test"] + 1, evaluator.time_coordinates.shape[-1])
+    )
+
+    with pytest.raises(ValueError, match="prediction rows"):
+        evaluator.pred_survs = bad_curves
+
+
+def test_set_prediction_inputs_updates_curves_and_times_together(evaluator_data):
+    evaluator = evaluator_data["evaluator"]
+    original_times = evaluator.predicted_event_times.copy()
+    new_time_grid = np.array([0.0, 1.0, 3.0, 7.0])
+    new_curves = np.exp(
+        -0.25 * np.outer(np.ones(evaluator_data["n_test"]), new_time_grid)
+    )
+
+    evaluator.set_prediction_inputs(
+        pred_survs=new_curves, time_coordinates=new_time_grid
+    )
+
+    assert evaluator.ndim_surv == 2
+    assert evaluator.ndim_time == 1
+    np.testing.assert_allclose(evaluator.time_coordinates, new_time_grid)
+    assert evaluator.pred_survs.shape == (evaluator_data["n_test"], new_time_grid.size)
+    assert not np.allclose(evaluator.predicted_event_times, original_times)
+
+
+def test_set_prediction_inputs_rejects_empty_update(evaluator_data):
+    with pytest.raises(ValueError, match="at least one"):
+        evaluator_data["evaluator"].set_prediction_inputs()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -88,6 +88,32 @@ def test_prediction_utilities(evaluator_data):
     np.testing.assert_allclose(quantile_intervals, intervals)
 
 
+def test_survival_evaluator_rejects_prediction_row_count_mismatch():
+    with pytest.raises(ValueError, match="prediction rows"):
+        SurvivalEvaluator(
+            pred_survs=np.ones((3, 3)),
+            time_coordinates=np.array([0.0, 1.0, 2.0]),
+            event_times=np.array([1.0, 2.0]),
+            event_indicators=np.array([1, 0]),
+        )
+
+
+def test_survival_evaluator_rejects_time_coordinate_row_count_mismatch():
+    with pytest.raises(ValueError, match="prediction rows"):
+        SurvivalEvaluator(
+            pred_survs=np.array([1.0, 0.8, 0.5]),
+            time_coordinates=np.array(
+                [
+                    [0.0, 1.0, 2.0],
+                    [0.0, 1.5, 3.0],
+                    [0.0, 2.0, 4.0],
+                ]
+            ),
+            event_times=np.array([1.0, 2.0]),
+            event_indicators=np.array([1, 0]),
+        )
+
+
 def test_predict_interval_accepts_matching_quantile_range_and_coverage_level(
     evaluator_data,
 ):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -453,6 +453,36 @@ def test_pred_survs_setter_rejects_prediction_row_count_mismatch(evaluator_data)
         evaluator.pred_survs = bad_curves
 
 
+def test_pred_survs_setter_accepts_raw_curves_after_zero_padding():
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.array([[0.8, 0.6, 0.4], [0.9, 0.7, 0.5]]),
+        time_coordinates=np.array([1.0, 2.0, 3.0]),
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 0]),
+    )
+
+    evaluator.pred_survs = np.array([[0.7, 0.5, 0.2], [0.8, 0.6, 0.3]])
+
+    assert evaluator.pred_survs.shape == (2, 4)
+    np.testing.assert_allclose(evaluator.pred_survs[:, 0], [1.0, 1.0])
+    np.testing.assert_allclose(evaluator.time_coordinates, [0.0, 1.0, 2.0, 3.0])
+
+
+def test_time_coordinates_setter_accepts_raw_grid_after_zero_padding():
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.array([[0.8, 0.6, 0.4], [0.9, 0.7, 0.5]]),
+        time_coordinates=np.array([1.0, 2.0, 3.0]),
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 0]),
+    )
+
+    evaluator.time_coordinates = np.array([2.0, 4.0, 6.0])
+
+    assert evaluator.time_coordinates.shape == (4,)
+    np.testing.assert_allclose(evaluator.time_coordinates, [0.0, 2.0, 4.0, 6.0])
+    np.testing.assert_allclose(evaluator.pred_survs[:, 0], [1.0, 1.0])
+
+
 def test_set_prediction_inputs_updates_curves_and_times_together(evaluator_data):
     evaluator = evaluator_data["evaluator"]
     original_times = evaluator.predicted_event_times.copy()
@@ -470,8 +500,3 @@ def test_set_prediction_inputs_updates_curves_and_times_together(evaluator_data)
     np.testing.assert_allclose(evaluator.time_coordinates, new_time_grid)
     assert evaluator.pred_survs.shape == (evaluator_data["n_test"], new_time_grid.size)
     assert not np.allclose(evaluator.predicted_event_times, original_times)
-
-
-def test_set_prediction_inputs_rejects_empty_update(evaluator_data):
-    with pytest.raises(ValueError, match="at least one"):
-        evaluator_data["evaluator"].set_prediction_inputs()

--- a/tests/test_interval_cen_evaluator.py
+++ b/tests/test_interval_cen_evaluator.py
@@ -44,6 +44,32 @@ def test_h_statistic_interval_one_calibration_includes_prediction_one():
     np.testing.assert_allclose(expected, [0.1, 0.4, 0.85])
 
 
+def test_interval_cen_evaluator_rejects_prediction_row_count_mismatch():
+    with pytest.raises(ValueError, match="prediction rows"):
+        IntervalCenEvaluator(
+            pred_survs=np.ones((3, 3)),
+            time_coordinates=np.array([0.0, 1.0, 2.0]),
+            left_limits=np.array([0.5, 1.5]),
+            right_limits=np.array([1.0, 2.0]),
+        )
+
+
+def test_interval_cen_evaluator_rejects_time_coordinate_row_count_mismatch():
+    with pytest.raises(ValueError, match="prediction rows"):
+        IntervalCenEvaluator(
+            pred_survs=np.array([1.0, 0.8, 0.5]),
+            time_coordinates=np.array(
+                [
+                    [0.0, 1.0, 2.0],
+                    [0.0, 1.5, 3.0],
+                    [0.0, 2.0, 4.0],
+                ]
+            ),
+            left_limits=np.array([0.5, 1.5]),
+            right_limits=np.array([1.0, 2.0]),
+        )
+
+
 @pytest.fixture(scope="module")
 def interval_evaluator():
     df = _load_breast_data()

--- a/tests/test_interval_cen_evaluator.py
+++ b/tests/test_interval_cen_evaluator.py
@@ -70,6 +70,34 @@ def test_interval_cen_evaluator_rejects_time_coordinate_row_count_mismatch():
         )
 
 
+def test_interval_cen_time_coordinates_setter_refreshes_dimension_metadata():
+    evaluator = IntervalCenEvaluator(
+        pred_survs=np.array([[1.0, 0.8, 0.5], [1.0, 0.7, 0.4]]),
+        time_coordinates=np.array([0.0, 1.0, 2.0]),
+        left_limits=np.array([0.5, 1.5]),
+        right_limits=np.array([1.0, 2.0]),
+    )
+
+    evaluator.time_coordinates = np.array(
+        [[0.0, 1.0, 2.0], [0.0, 1.5, 3.0]]
+    )
+
+    assert evaluator.ndim_time == 2
+    assert evaluator.predict_probability_from_curve(1.0).shape == (2,)
+
+
+def test_interval_cen_pred_survs_setter_rejects_prediction_row_count_mismatch():
+    evaluator = IntervalCenEvaluator(
+        pred_survs=np.array([[1.0, 0.8, 0.5], [1.0, 0.7, 0.4]]),
+        time_coordinates=np.array([0.0, 1.0, 2.0]),
+        left_limits=np.array([0.5, 1.5]),
+        right_limits=np.array([1.0, 2.0]),
+    )
+
+    with pytest.raises(ValueError, match="prediction rows"):
+        evaluator.pred_survs = np.ones((3, 3))
+
+
 @pytest.fixture(scope="module")
 def interval_evaluator():
     df = _load_breast_data()

--- a/tests/test_multiple_brier.py
+++ b/tests/test_multiple_brier.py
@@ -10,6 +10,40 @@ from SurvivalEVAL.Evaluations.BrierScore import (
 
 
 @pytest.mark.parametrize("ipcw", [True, False])
+def test_single_brier_score_treats_censored_at_target_time_as_event_free(
+    ipcw: bool,
+) -> None:
+    score = single_brier_score(
+        preds=np.array([0.2, 0.8, 0.9]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 0]),
+        train_event_times=np.array([4.0, 5.0, 6.0]),
+        train_event_indicators=np.array([1, 1, 1]),
+        target_time=2.0,
+        ipcw=ipcw,
+    )
+
+    assert score == pytest.approx(0.03)
+
+
+@pytest.mark.parametrize("ipcw", [True, False])
+def test_brier_multiple_points_treats_censored_at_target_time_as_event_free(
+    ipcw: bool,
+) -> None:
+    scores = brier_multiple_points(
+        pred_mat=np.array([[0.2], [0.8], [0.9]]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 0]),
+        train_event_times=np.array([4.0, 5.0, 6.0]),
+        train_event_indicators=np.array([1, 1, 1]),
+        target_times=np.array([2.0]),
+        ipcw=ipcw,
+    )
+
+    np.testing.assert_allclose(scores, [0.03])
+
+
+@pytest.mark.parametrize("ipcw", [True, False])
 def test_brier_multiple_points_matches_single(ipcw: bool) -> None:
     pred_mat = np.array(
         [

--- a/tests/test_multiple_brier.py
+++ b/tests/test_multiple_brier.py
@@ -90,3 +90,37 @@ def test_brier_multiple_points_ic_matches_single_uncensored() -> None:
     np.testing.assert_allclose(
         multi_scores, single_scores, rtol=1e-6, atol=1e-8, equal_nan=True
     )
+
+
+def test_brier_score_ic_tsouprou_treats_exact_event_time_as_dead() -> None:
+    train_left_limits = np.array([0.5, 1.0, 2.0])
+    train_right_limits = np.array([0.5, 1.0, 2.0])
+
+    score = brier_score_ic(
+        preds=np.array([0.0]),
+        left_limits=np.array([1.0]),
+        right_limits=np.array([1.0]),
+        train_left_limits=train_left_limits,
+        train_right_limits=train_right_limits,
+        target_time=1.0,
+        method="Tsouprou-marginal",
+    )
+
+    assert score == pytest.approx(0.0)
+
+
+def test_brier_multiple_points_ic_tsouprou_uses_open_closed_interval() -> None:
+    train_left_limits = np.array([0.5, 1.0, 2.0])
+    train_right_limits = np.array([0.5, 1.0, 2.0])
+
+    scores = brier_multiple_points_ic(
+        pred_mat=np.array([[1.0, 0.0, 0.0]]),
+        left_limits=np.array([1.0]),
+        right_limits=np.array([1.0]),
+        target_times=np.array([0.5, 1.0, 1.5]),
+        train_left_limits=train_left_limits,
+        train_right_limits=train_right_limits,
+        method="Tsouprou-marginal",
+    )
+
+    np.testing.assert_allclose(scores, [0.0, 0.0, 0.0])

--- a/tests/test_other_metrics.py
+++ b/tests/test_other_metrics.py
@@ -1,7 +1,19 @@
 import numpy as np
 import pytest
 
+from SurvivalEVAL.Evaluations.AreaUnderROCurve import auc
 from SurvivalEVAL.Evaluations.OtherMetrics import cov
+
+
+def test_auc_treats_censored_at_target_time_as_event_free():
+    value = auc(
+        predict_probs=np.array([0.2, 0.1, 0.9]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 0]),
+        target_time=2.0,
+    )
+
+    assert value == pytest.approx(0.5)
 
 
 def test_cov_computes_event_time_coefficient_of_variation():

--- a/tests/test_quantile_evaluator.py
+++ b/tests/test_quantile_evaluator.py
@@ -78,6 +78,17 @@ def test_quantile_prediction_utilities(quantile_evaluator):
     assert np.all(intervals[:, 0] <= intervals[:, 1])
 
 
+def test_quantile_evaluator_accepts_list_quantile_levels():
+    evaluator = QuantileRegEvaluator(
+        pred_regs=np.array([[0.0, 2.0], [0.0, 3.0]]),
+        quantile_levels=[0.25, 0.5],
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 1]),
+    )
+
+    np.testing.assert_allclose(evaluator.pred_survs, [0.75, 0.5])
+
+
 def test_quantile_concordance_and_auc(quantile_evaluator):
     evaluator = quantile_evaluator["evaluator"]
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,6 +10,8 @@ from SurvivalEVAL.Evaluations.util import (
     align_curve_and_time_coordinates,
     check_monotonicity,
     make_monotonic,
+    predict_multi_probs_from_curve,
+    predict_prob_from_curve,
     survival_to_quantile,
     zero_padding,
 )
@@ -51,6 +53,64 @@ def test_align_curve_and_time_coordinates_accepts_external_sample_count():
     )
 
     assert curves.shape == times.shape == (2, 3)
+
+
+def test_zero_padding_supports_1d_curve_and_1d_time_coordinates():
+    curve = np.array([0.8, 0.5, 0.1])
+    time_coordinates = np.array([1.0, 2.0, 3.0])
+
+    with pytest.warns(UserWarning, match="first time coordinate"):
+        padded_curve, padded_times = zero_padding(curve, time_coordinates)
+
+    np.testing.assert_allclose(padded_curve, [1.0, 0.8, 0.5, 0.1])
+    np.testing.assert_allclose(padded_times, [0.0, 1.0, 2.0, 3.0])
+    assert isinstance(padded_curve, np.ndarray)
+    assert isinstance(padded_times, np.ndarray)
+    assert padded_curve.ndim == 1
+
+
+@pytest.mark.parametrize(
+    ("pred_survs", "time_coordinates", "message"),
+    [
+        ([0.8, 0.5, 0.1], np.array([1.0, 2.0, 3.0]), "pred_survs"),
+        (np.array([0.8, 0.5, 0.1]), [1.0, 2.0, 3.0], "time_coordinates"),
+        (
+            np.array(["0.8", "0.5", "0.1"]),
+            np.array([1.0, 2.0, 3.0]),
+            "pred_survs",
+        ),
+        (
+            np.array([0.8, 0.5, 0.1]),
+            np.array(["1.0", "2.0", "3.0"]),
+            "time_coordinates",
+        ),
+    ],
+)
+def test_zero_padding_rejects_invalid_input_datatypes(
+    pred_survs, time_coordinates, message
+):
+    with pytest.raises(TypeError, match=message):
+        zero_padding(pred_survs, time_coordinates)
+
+
+def test_zero_padding_rejects_empty_inputs():
+    with pytest.raises(ValueError, match="non-empty"):
+        zero_padding(np.array([]), np.array([]))
+
+
+def test_zero_padding_rejects_negative_time_coordinates():
+    with pytest.raises(ValueError, match="non-negative"):
+        zero_padding(np.array([1.0, 0.8, 0.5]), np.array([-1.0, 1.0, 2.0]))
+
+
+def test_zero_padding_preserves_1d_curve_that_already_starts_at_zero():
+    curve = np.array([0.8, 0.5, 0.1])
+    time_coordinates = np.array([0.0, 2.0, 3.0])
+
+    padded_curve, padded_times = zero_padding(curve, time_coordinates)
+
+    np.testing.assert_allclose(padded_curve, curve)
+    np.testing.assert_allclose(padded_times, time_coordinates)
 
 
 @pytest.mark.parametrize(
@@ -251,6 +311,65 @@ def test_make_monotonic_bootstrap_supports_increasing_cdf():
 def test_make_monotonic_rejects_invalid_inputs(curves, times, kwargs, message):
     with pytest.raises(ValueError, match=message):
         make_monotonic(curves, times, **kwargs)
+
+
+def test_predict_prob_from_curve_pads_time_grid_starting_after_zero():
+    with pytest.warns(UserWarning, match="first time coordinate"):
+        prob = predict_prob_from_curve(
+            survival_curve=np.array([0.8, 0.5, 0.2]),
+            times_coordinate=np.array([1.0, 2.0, 3.0]),
+            target_time=0.5,
+        )
+
+    assert prob == pytest.approx(0.9)
+
+
+def test_predict_prob_from_curve_accepts_curve_below_one_at_origin():
+    prob = predict_prob_from_curve(
+        survival_curve=np.array([0.9, 0.8, 0.5]),
+        times_coordinate=np.array([0.0, 1.0, 2.0]),
+        target_time=1.0,
+    )
+
+    assert prob == pytest.approx(0.8)
+
+
+def test_predict_prob_from_curve_rejects_negative_target_time():
+    with pytest.raises(ValueError, match="non-negative"):
+        predict_prob_from_curve(
+            survival_curve=np.array([1.0, 0.8, 0.5]),
+            times_coordinate=np.array([0.0, 1.0, 2.0]),
+            target_time=-0.1,
+        )
+
+
+def test_predict_prob_from_curve_rejects_negative_time_coordinates():
+    with pytest.raises(ValueError, match="non-negative"):
+        predict_prob_from_curve(
+            survival_curve=np.array([1.0, 0.8, 0.5]),
+            times_coordinate=np.array([-1.0, 1.0, 2.0]),
+            target_time=1.0,
+        )
+
+
+def test_predict_multi_probs_from_curve_pads_time_grid_starting_after_zero():
+    with pytest.warns(UserWarning, match="first time coordinate"):
+        probs = predict_multi_probs_from_curve(
+            survival_curve=np.array([0.8, 0.5, 0.2]),
+            times_coordinate=np.array([1.0, 2.0, 3.0]),
+            target_times=np.array([0.0, 0.5, 1.0]),
+        )
+
+    np.testing.assert_allclose(probs, [1.0, 0.9, 0.8])
+
+
+def test_predict_multi_probs_from_curve_rejects_negative_target_times():
+    with pytest.raises(ValueError, match="non-negative"):
+        predict_multi_probs_from_curve(
+            survival_curve=np.array([1.0, 0.8, 0.5]),
+            times_coordinate=np.array([0.0, 1.0, 2.0]),
+            target_times=np.array([0.5, -0.1]),
+        )
 
 
 def test_survival_to_quantile_rejects_increasing_survival_probabilities():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -176,6 +176,15 @@ def test_check_monotonicity_checks_each_row_and_preserves_legacy_default():
     assert not check_monotonicity(increasing, direction="decreasing")
 
 
+def test_check_monotonicity_handles_repeated_infinities():
+    increasing = np.array([[0.0, np.inf, np.inf], [1.0, 2.0, np.inf]])
+    decreasing = np.array([[np.inf, np.inf, 2.0], [np.inf, 1.0, 1.0]])
+
+    assert check_monotonicity(increasing, direction="increasing")
+    assert check_monotonicity(decreasing, direction="decreasing")
+    assert not check_monotonicity(increasing, direction="decreasing")
+
+
 def test_check_monotonicity_rejects_unknown_direction():
     with pytest.raises(ValueError, match="direction"):
         check_monotonicity([0.0, 1.0], direction="sideways")
@@ -406,6 +415,16 @@ def test_survival_to_quantile_rejects_decreasing_quantile_levels():
             time_coordinates=[[0.0, 1.0, 2.0]],
             quantile_levels=[0.5, 0.25],
         )
+
+
+def test_survival_to_quantile_handles_all_one_survival_curve_with_pchip():
+    result = survival_to_quantile(
+        surv_prob=[[1.0, 1.0, 1.0]],
+        time_coordinates=[[0.0, 1.0, 2.0]],
+        quantile_levels=[0.0, 0.25, 0.5],
+    )
+
+    np.testing.assert_allclose(result, [[0.0, np.inf, np.inf]])
 
 
 def test_auprc_rejects_decreasing_cdf():


### PR DESCRIPTION
# Description

This PR hardens evaluator prediction-input updates and fixes several survival metric edge cases. It validates prediction row counts before accepting curve/time-grid inputs, normalizes string options across evaluator and metric APIs, and corrects target-time boundary handling for right-censored and interval-censored metrics.

## Updates

1. Add `set_prediction_inputs` and reuse it from evaluator initialization/property setters so curve and time-grid updates are validated, zero-padded, and cache-invalidated together.
2. Make method, interpolation, tie, and binning option strings case-insensitive across evaluators and metric utilities.
3. Extend utility behavior for 1D zero-padding, vectorized multi-time survival probability tails, repeated infinities in monotonicity checks, and all-one survival-to-quantile conversion.
4. Clean up evaluator and interval-censored evaluator docs/comments, update the cross-validation calibration notebook quantile levels, and fix setup license metadata.

## Fixes

1. Reject mismatched prediction row counts when `pred_survs` or 2D `time_coordinates` disagree with the number of testing samples.
2. Treat right-censored observations exactly at the target time as event-free in single- and multi-time Brier scores.
3. Apply left-open, right-closed interval semantics `(left, right]` for interval-censored Tsouprou Brier status at exact boundaries.
4. Correct AUC target-time labeling so only observed events at or before the target are positives after excluding earlier censored samples.
5. Handle survival-to-quantile rows with no CDF increase as `0` at quantile 0 and `inf` for positive quantiles.

## Mandatory Checklist

- [x] All new or modified features have corresponding test cases.

- [x] I have run all the tests, using `pytest`, and this is the log I get:

```bash
conda run -n SurvEVAL pytest
============================= test session starts ==============================
platform linux -- Python 3.11.10, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/shiang/Documents/GithubRepository/SurvivalEVAL
configfile: pyproject.toml
plugins: anyio-4.6.2
collected 131 items

...

======================= 131 passed, 17 warnings in 6.20s =======================
```

- [x] All new functions, classes, and modules contain clear docstrings and inline comments.

- [ ] All jupyter notebooks are runnable with expected results. 

- [ ] I have reformatted and ran `isort .` and `black .` (in this same order) on the codebase. 

- [x] I have updated the README and added or edited any new scripts to the integration tests. 

- [x] I have ensured sufficient coverage on the newly implemented features.

- [x] I have made sure that both the `requirements.txt` and `pyproject.toml` files are updated according to the newly introduced dependencies. N/A: no new dependencies were introduced.

- [x] Paste the remaining code TODOs using the command `grep -rI --color=auto --exclude-dir={.git,__pycache__,env_folder,.venv,venv,.cache,output,.github,} 'TODO' .` here, and explain them if necessary:

```bash
./setup.py:TODO:
./SurvivalEVAL/Evaluations/MeanError.py:                # Numpy will throw a warning if afterward_event_times are all false. TODO: consider change the code.
./SurvivalEVAL/Evaluations/MeanError.py:    # TODO: We need to move the logarithm transformation later after we calculate a best-guess.
```

Note: the literal grep command on this local checkout also reports ignored `tests/private/*` TODOs; those are omitted above because `tests/private/` is local/private and not CI-visible.
