### PR TITLE
Add IPCW and tau truncation to concordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 2026-06-16: Version 0.7.0
+
+1. Add Uno's right-censored concordance index through the `"Uno"` method, with `"IPCW"` kept as an alias.
+2. Add `tau` truncation support for right-censored concordance methods, using strict before-`tau` anchor filtering.
+3. Improve right-censored concordance pair accounting for Harrell/Naive, Uno/IPCW, and Margin methods, including
+   tie handling and final-block IPCW edge cases.
+4. Update evaluator concordance wrappers and docstrings to expose the new right-censored concordance options.
+5. Add regression tests for Uno/IPCW weighting, `tau` truncation, tie policies, Margin behavior, and evaluator
+   forwarding.
+
 ## 2026-06-11: Version 0.6.3
 
 1. Fix zero-padding and prediction-input update paths so 1-D survival curves, raw replacements after padding, sample-specific time grids, and row-count mismatches are handled consistently in right- and interval-censored evaluators.

--- a/README.md
+++ b/README.md
@@ -181,12 +181,21 @@ These metrics compare predicted survival times with observed event/censoring
 times. Predicted times are derived from survival curves using the configured
 `predict_time_method`: `"Median"`, `"Mean"`, or `"RMST"`.
 
-- Concordance index: `evl.concordance(method="Harrell")`
+- Concordance index: `evl.concordance(method="Harrell")` or
+  `evl.concordance(method="Naive")`
+- IPCW/Uno concordance: `evl.concordance(method="Uno")` or
+  `evl.concordance(method="IPCW")`
 - Margin concordance: `evl.concordance(method="Margin")`
+- Optional concordance truncation: `evl.concordance(..., tau=...)`
 - Mean absolute error: `evl.mae(method=...)`
 - Mean squared error: `evl.mse(method=...)`
 - Root mean squared error: `evl.rmse(method=...)`
 - Log-rank and weighted log-rank tests: `evl.log_rank(...)`
+
+`"Uno"`, `"IPCW"`, and `"Margin"` concordance require training event times
+and indicators. For right-censored concordance, `tau` keeps pairs whose
+effective earlier or anchor time is strictly before `tau`; when omitted, no
+truncation is applied.
 
 Error methods include `"Uncensored"`, `"Hinge"`, `"Margin"`, `"IPCW-T"`,
 `"IPCW-D"`, and `"Pseudo_obs"`.

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -108,16 +108,16 @@ def concordance(
         bg_event_times[~event_indicators] = best_guesses
     else:
         raise TypeError("Method for calculating concordance is unrecognized.")
-    # risk_ties means predicted times are the same while true times are different.
-    # time_ties means true times are the same while predicted times are different.
-    # c_index, concordant_pairs, discordant_pairs, risk_ties, time_ties = metrics.concordance_index_censored(
+    # risk_tie_pairs are comparable pairs whose predictions/risk scores tie.
+    # time_tie_pairs are non-comparable observed-event pairs with the same event time.
+    # c_index, concordant_pairs, discordant_pairs, risk_tie_pairs, time_tie_pairs = metrics.concordance_index_censored(
     #     event_indicators, event_times, estimate=risk)
     (
         c_index,
         concordant_pairs,
         discordant_pairs,
-        risk_ties,
-        time_ties,
+        risk_tie_pairs,
+        time_tie_pairs,
     ) = _estimate_concordance_index(
         event_indicators,
         event_times,
@@ -129,17 +129,21 @@ def concordance(
         total_pairs = concordant_pairs + discordant_pairs
         c_index = concordant_pairs / total_pairs
     elif ties == "time":
-        total_pairs = concordant_pairs + discordant_pairs + time_ties
-        concordant_pairs = concordant_pairs + 0.5 * time_ties
+        total_pairs = concordant_pairs + discordant_pairs + time_tie_pairs
+        concordant_pairs = concordant_pairs + 0.5 * time_tie_pairs
         c_index = concordant_pairs / total_pairs
     elif ties == "risk":
         # This should be the same as original outputted c_index from above
-        total_pairs = concordant_pairs + discordant_pairs + risk_ties
-        concordant_pairs = concordant_pairs + 0.5 * risk_ties
+        total_pairs = concordant_pairs + discordant_pairs + risk_tie_pairs
+        concordant_pairs = concordant_pairs + 0.5 * risk_tie_pairs
         c_index = concordant_pairs / total_pairs
     elif ties == "all":
-        total_pairs = concordant_pairs + discordant_pairs + risk_ties + time_ties
-        concordant_pairs = concordant_pairs + 0.5 * (risk_ties + time_ties)
+        total_pairs = (
+            concordant_pairs + discordant_pairs + risk_tie_pairs + time_tie_pairs
+        )
+        concordant_pairs = concordant_pairs + 0.5 * (
+            risk_tie_pairs + time_tie_pairs
+        )
         c_index = concordant_pairs / total_pairs
     else:
         error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
@@ -160,7 +164,8 @@ def _estimate_concordance_index(
     Estimate the concordance index.
     This backbone of this function is borrowed from scikit-survival:
     https://github.com/sebp/scikit-survival/blob/4e664d8e4fe5e5b55006e3913f2bbabcf2455496/sksurv/metrics.py#L85-L118
-    In here, we make modifications to the original function to allow for partial weights and best-guess times (margin times).
+    In here, we make modifications to the original function to allow for partial
+    weights and best-guess times (margin times).
 
     All functions in scikit-survival are licensed under the GPLv3 License:
     https://github.com/sebp/scikit-survival/blob/master/COPYING
@@ -190,19 +195,21 @@ def _estimate_concordance_index(
         The number of concordant pairs.
     discordant: float
         The number of discordant pairs.
-    tied_risk: float
-        The number of tied risk scores.
-    tied_time: float
-        The number of tied times.
+    risk_tie_pairs: float
+        The weighted number of comparable pairs tied on risk score.
+    time_tie_pairs: float
+        The weighted number of non-comparable observed-event pairs tied on event time.
     -------
     """
     order = np.argsort(event_time, kind="stable")
 
-    comparable, tied_time, weight = _get_comparable(event_indicator, event_time, order)
+    comparable, time_tie_pairs, weight = _get_comparable(
+        event_indicator, event_time, order
+    )
 
     if partial_weights is not None:
         event_indicator = np.ones_like(event_indicator)
-        comparable_2, tied_time, weight = _get_comparable(
+        comparable_2, time_tie_pairs, weight = _get_comparable(
             event_indicator, bg_event_time, order, partial_weights
         )
         for ind, mask in comparable.items():
@@ -216,7 +223,7 @@ def _estimate_concordance_index(
 
     concordant = 0
     discordant = 0
-    tied_risk = 0
+    risk_tie_pairs = 0.0
     numerator = 0.0
     denominator = 0.0
     for ind, mask in comparable.items():
@@ -246,13 +253,13 @@ def _estimate_concordance_index(
         numerator += n_con + 0.5 * n_ties
         denominator += np.dot(w_i, mask.T)
 
-        tied_risk += n_ties
+        risk_tie_pairs += n_ties
         concordant += n_con
         # discordant += est.size - n_con - n_ties
         discordant += np.dot(w_i, mask.T) - n_con - n_ties
 
     c_index = numerator / denominator
-    return c_index, concordant, discordant, tied_risk, tied_time
+    return c_index, concordant, discordant, risk_tie_pairs, time_tie_pairs
 
 
 def _get_comparable(
@@ -288,8 +295,8 @@ def _get_comparable(
     comparable: dict
         A dictionary where the keys are the indices of the samples with events, and the values are boolean masks
         indicating which samples are comparable to the key sample.
-    tied_time: int
-        The number of tied times.
+    time_tie_pairs: float
+        The number of weighted tied-time pairs between observed events.
     weight: dict
         A dictionary where the keys are the indices of the samples with events, and the values are the weights
         for each comparable sample.
@@ -298,7 +305,7 @@ def _get_comparable(
     if partial_weights is None:
         partial_weights = np.ones_like(event_indicator, dtype=float)
     n_samples = len(event_time)
-    tied_time = 0
+    time_tie_pairs = 0.0
     comparable = {}
     weight = {}
 
@@ -320,11 +327,15 @@ def _get_comparable(
                 # an event is comparable to censored samples at same time point
                 mask[i:end] = censored_at_same_time
                 comparable[j] = mask
-                tied_time += censored_at_same_time.sum()
+                event_at_later_same_time = event_indicator[order[j + 1 : end]]
+                time_tie_pairs += (
+                    partial_weights[order[j]]
+                    * partial_weights[order[j + 1 : end]][event_at_later_same_time]
+                ).sum()
                 weight[j] = partial_weights[order] * partial_weights[order[j]]
         i = end
 
-    return comparable, tied_time, weight
+    return comparable, time_tie_pairs, weight
 
 
 def _get_comparable_ic(

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -145,17 +145,32 @@ def concordance(
 
         censoring_model = KaplanMeier(train_event_times, ~train_event_indicators)
         censoring_survival = censoring_model.predict(event_times)
-        contributing_anchors = _right_censored_contributing_event_anchor_mask(
-            event_indicators, event_times, tau
-        )
-        if np.any(censoring_survival[contributing_anchors] <= 0):
+        observed_anchors = event_indicators & _is_before_tau(event_times, tau)
+
+        # Uno/IPCW only needs positive censoring survival for anchors whose
+        # weights can actually be used. Every non-final event-time block has
+        # later samples as candidates. In the final observed-time block, an
+        # event anchor still contributes if there is a same-time censored sample
+        # or another same-time event for the time-tie count. The only observed
+        # anchor that cannot contribute is a singleton event in the final block,
+        # so exclude just that case from the zero-survival check and weight
+        # assignment.
+        final_time = np.max(event_times)
+        final_block = event_times == final_time
+        final_events = final_block & event_indicators
+        final_event_count = np.count_nonzero(final_events)
+        final_has_censored_candidate = np.any(final_block & ~event_indicators)
+        if final_event_count == 1 and not final_has_censored_candidate:
+            observed_anchors[final_events] = False
+
+        if np.any(censoring_survival[observed_anchors] <= 0):
             raise ValueError(
                 "Censoring survival probability is zero for at least one observed event; "
                 "cannot estimate Uno's concordance."
             )
 
         ipcw_weights = np.zeros_like(event_times, dtype=float)
-        ipcw_weights[contributing_anchors] = 1 / censoring_survival[contributing_anchors]
+        ipcw_weights[observed_anchors] = 1 / censoring_survival[observed_anchors]
         counts = _right_censored_risk_counts(
             event_indicators,
             event_times,
@@ -356,33 +371,6 @@ def _right_censored_risk_counts(
             )
 
     return counts
-
-
-def _right_censored_contributing_event_anchor_mask(
-    event_indicator: np.ndarray,
-    event_time: np.ndarray,
-    tau: Optional[float] = None,
-) -> np.ndarray:
-    """Return observed-event anchors that can contribute raw concordance counts."""
-    contributing_anchors = np.zeros(event_time.shape[0], dtype=bool)
-
-    for block, later_samples in _iter_time_blocks(event_time):
-        if tau is not None and event_time[block[0]] >= tau:
-            break
-
-        event_anchors = block[event_indicator[block]]
-        if event_anchors.shape[0] == 0:
-            continue
-
-        has_time_ties = event_anchors.shape[0] > 1
-        has_comparable_candidates = (
-            later_samples.shape[0] > 0 or np.any(~event_indicator[block])
-        )
-        if has_time_ties or has_comparable_candidates:
-            contributing_anchors[event_anchors] = True
-
-    return contributing_anchors
-
 
 def _margin_counts(
     event_indicator: np.ndarray,

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -145,15 +145,17 @@ def concordance(
 
         censoring_model = KaplanMeier(train_event_times, ~train_event_indicators)
         censoring_survival = censoring_model.predict(event_times)
-        observed_anchors = event_indicators & _is_before_tau(event_times, tau)
-        if np.any(censoring_survival[observed_anchors] <= 0):
+        contributing_anchors = _right_censored_contributing_event_anchor_mask(
+            event_indicators, event_times, tau
+        )
+        if np.any(censoring_survival[contributing_anchors] <= 0):
             raise ValueError(
                 "Censoring survival probability is zero for at least one observed event; "
                 "cannot estimate Uno's concordance."
             )
 
         ipcw_weights = np.zeros_like(event_times, dtype=float)
-        ipcw_weights[observed_anchors] = 1 / censoring_survival[observed_anchors]
+        ipcw_weights[contributing_anchors] = 1 / censoring_survival[contributing_anchors]
         counts = _right_censored_risk_counts(
             event_indicators,
             event_times,
@@ -354,6 +356,32 @@ def _right_censored_risk_counts(
             )
 
     return counts
+
+
+def _right_censored_contributing_event_anchor_mask(
+    event_indicator: np.ndarray,
+    event_time: np.ndarray,
+    tau: Optional[float] = None,
+) -> np.ndarray:
+    """Return observed-event anchors that can contribute raw concordance counts."""
+    contributing_anchors = np.zeros(event_time.shape[0], dtype=bool)
+
+    for block, later_samples in _iter_time_blocks(event_time):
+        if tau is not None and event_time[block[0]] >= tau:
+            break
+
+        event_anchors = block[event_indicator[block]]
+        if event_anchors.shape[0] == 0:
+            continue
+
+        has_time_ties = event_anchors.shape[0] > 1
+        has_comparable_candidates = (
+            later_samples.shape[0] > 0 or np.any(~event_indicator[block])
+        )
+        if has_time_ties or has_comparable_candidates:
+            contributing_anchors[event_anchors] = True
+
+    return contributing_anchors
 
 
 def _margin_counts(

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -38,11 +38,8 @@ def concordance(
         0 denotes a censored observation.
     method: str, optional (default="Harrell")
         A string indicating the method for constructing the pairs of samples.
-        "Harrell": the pairs are constructed by comparing the predicted survival time of each sample with the
-        event time of all other samples. The pairs are only constructed between samples with comparable
-        event times. For example, if i-th sample has a censor time of 10, then the pairs are constructed by
-        comparing the predicted survival time of sample i with the event time of all samples with event
-        time of 10 or less.
+        "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
+        event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
         "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
         will be calculated and used to construct the pairs.
     ties: str, optional (default="Risk")

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Iterator, Optional, Tuple
 
 import numpy as np
 
@@ -8,6 +9,47 @@ from SurvivalEVAL.NonparametricEstimator.SingleEvent import (
     KaplanMeierArea,
     TurnbullEstimatorLifelines,
 )
+
+
+@dataclass
+class ConcordanceCounts:
+    """Raw concordance pair counts before tie-mode finalization.
+
+    Attributes
+    ----------
+    concordant: float
+        Weighted count of comparable pairs with correctly ordered risks.
+    discordant: float
+        Weighted count of comparable pairs with incorrectly ordered risks.
+    risk_tie_pairs: float
+        Weighted count of comparable pairs tied on risk.
+    time_tie_pairs: float
+        Weighted count of same-time event pairs.
+    """
+
+    concordant: float = 0.0
+    discordant: float = 0.0
+    risk_tie_pairs: float = 0.0
+    time_tie_pairs: float = 0.0
+
+    def __iadd__(self, other: "ConcordanceCounts") -> "ConcordanceCounts":
+        """Add another count object in place.
+
+        Parameters
+        ----------
+        other: ConcordanceCounts
+            Concordance counts to add to this object.
+
+        Returns
+        -------
+        ConcordanceCounts
+            This count object after mutation.
+        """
+        self.concordant += other.concordant
+        self.discordant += other.discordant
+        self.risk_tie_pairs += other.risk_tie_pairs
+        self.time_tie_pairs += other.time_tie_pairs
+        return self
 
 
 def concordance(
@@ -76,8 +118,7 @@ def concordance(
 
     if method == "harrell":
         risks = -1 * predicted_times
-        partial_weights = None
-        bg_event_times = None
+        counts = _right_censored_risk_counts(event_indicators, event_times, risks)
     elif method == "margin":
         if train_event_times is None or train_event_indicators is None:
             error = "If 'Margin' is chosen, training set information must be provided."
@@ -106,236 +147,353 @@ def concordance(
 
         bg_event_times = np.copy(event_times)
         bg_event_times[~event_indicators] = best_guesses
+        counts = _margin_counts(
+            event_indicators,
+            event_times,
+            estimate=risks,
+            bg_event_time=bg_event_times,
+            partial_weights=partial_weights,
+        )
     else:
         raise TypeError("Method for calculating concordance is unrecognized.")
-    # risk_tie_pairs are comparable pairs whose predictions/risk scores tie.
-    # time_tie_pairs are non-comparable observed-event pairs with the same event time.
-    # c_index, concordant_pairs, discordant_pairs, risk_tie_pairs, time_tie_pairs = metrics.concordance_index_censored(
-    #     event_indicators, event_times, estimate=risk)
-    (
-        c_index,
-        concordant_pairs,
-        discordant_pairs,
-        risk_tie_pairs,
-        time_tie_pairs,
-    ) = _estimate_concordance_index(
-        event_indicators,
-        event_times,
-        estimate=risks,
-        bg_event_time=bg_event_times,
-        partial_weights=partial_weights,
-    )
-    if ties == "none":
-        total_pairs = concordant_pairs + discordant_pairs
-        c_index = concordant_pairs / total_pairs
-    elif ties == "time":
-        total_pairs = concordant_pairs + discordant_pairs + time_tie_pairs
-        concordant_pairs = concordant_pairs + 0.5 * time_tie_pairs
-        c_index = concordant_pairs / total_pairs
-    elif ties == "risk":
-        # This should be the same as original outputted c_index from above
-        total_pairs = concordant_pairs + discordant_pairs + risk_tie_pairs
-        concordant_pairs = concordant_pairs + 0.5 * risk_tie_pairs
-        c_index = concordant_pairs / total_pairs
-    elif ties == "all":
-        total_pairs = (
-            concordant_pairs + discordant_pairs + risk_tie_pairs + time_tie_pairs
-        )
-        concordant_pairs = concordant_pairs + 0.5 * (
-            risk_tie_pairs + time_tie_pairs
-        )
-        c_index = concordant_pairs / total_pairs
-    else:
-        error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
-        raise TypeError(error)
 
-    return c_index, concordant_pairs, total_pairs
+    _check_has_any_pairs(counts)
+    return _finalize_counts(counts, ties)
 
 
-def _estimate_concordance_index(
-    event_indicator: np.ndarray,
-    event_time: np.ndarray,
-    estimate: np.ndarray,
-    bg_event_time: np.ndarray = None,
-    partial_weights: np.ndarray = None,
-    tied_tol: float = 1e-8,
-) -> tuple[float, float, float, float, float]:
-    """
-    Estimate the concordance index.
-    This backbone of this function is borrowed from scikit-survival:
-    https://github.com/sebp/scikit-survival/blob/4e664d8e4fe5e5b55006e3913f2bbabcf2455496/sksurv/metrics.py#L85-L118
-    In here, we make modifications to the original function to allow for partial
-    weights and best-guess times (margin times).
-
-    All functions in scikit-survival are licensed under the GPLv3 License:
-    https://github.com/sebp/scikit-survival/blob/master/COPYING
+def _finalize_counts(counts: ConcordanceCounts, ties: str) -> tuple[float, float, float]:
+    """Apply the requested tie policy to raw concordance counts.
 
     Parameters
     ----------
-    event_indicator: np.ndarray, shape = (n_samples,)
-        Binary event indicators: 1 denotes an observed event and 0 denotes a
-        censored observation.
-    event_time: np.ndarray, shape = (n_samples,)
-        The true survival times.
-    estimate: np.ndarray, shape = (n_samples,)
-        The estimated risk scores. A higher score should correspond to a higher risk.
-    bg_event_time: np.ndarray, shape = (n_samples,), optional (default=None)
-        The best-guess event times. For uncensored samples, this should be the same as the true event times.
-        For censored samples, this should be the best-guess time (margin time) for the censored samples.
-    partial_weights: np.ndarray, shape = (n_samples,), optional (default=None)
-        The partial weights for the censored samples.
-    tied_tol: float, optional (default=1e-8)
-        The tolerance for considering two estimated risk scores as tied.
+    counts: ConcordanceCounts
+        Raw concordance pair counts.
+    ties: str
+        One of ``"None"``, ``"Time"``, ``"Risk"``, or ``"All"``.
 
     Returns
     -------
     c_index: float
-        The concordance index.
-    concordant: float
-        The number of concordant pairs.
-    discordant: float
-        The number of discordant pairs.
-    risk_tie_pairs: float
-        The weighted number of comparable pairs tied on risk score.
-    time_tie_pairs: float
-        The weighted number of non-comparable observed-event pairs tied on event time.
-    -------
+        The concordance index after applying the requested tie policy.
+    concordant_pairs: float
+        The concordant-pair count after applying the requested tie policy.
+    total_pairs: float
+        The total pair count after applying the requested tie policy.
     """
-    order = np.argsort(event_time, kind="stable")
+    ties = ties.lower()
 
-    comparable, time_tie_pairs, weight = _get_comparable(
-        event_indicator, event_time, order
-    )
-
-    if partial_weights is not None:
-        event_indicator = np.ones_like(event_indicator)
-        comparable_2, time_tie_pairs, weight = _get_comparable(
-            event_indicator, bg_event_time, order, partial_weights
+    concordant_pairs = counts.concordant
+    if ties == "none":
+        total_pairs = counts.concordant + counts.discordant
+    elif ties == "time":
+        total_pairs = counts.concordant + counts.discordant + counts.time_tie_pairs
+        concordant_pairs += 0.5 * counts.time_tie_pairs
+    elif ties == "risk":
+        total_pairs = counts.concordant + counts.discordant + counts.risk_tie_pairs
+        concordant_pairs += 0.5 * counts.risk_tie_pairs
+    elif ties == "all":
+        total_pairs = (
+            counts.concordant
+            + counts.discordant
+            + counts.risk_tie_pairs
+            + counts.time_tie_pairs
         )
-        for ind, mask in comparable.items():
-            weight[ind][mask] = 1
-        comparable = comparable_2
+        concordant_pairs += 0.5 * (counts.risk_tie_pairs + counts.time_tie_pairs)
+    else:
+        error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
+        raise TypeError(error)
 
-    if len(comparable) == 0:
+    c_index = concordant_pairs / total_pairs if total_pairs != 0 else float("nan")
+    return c_index, concordant_pairs, total_pairs
+
+
+def _check_has_any_pairs(counts: ConcordanceCounts) -> None:
+    """Raise when no comparable or tied-time pairs were counted.
+
+    Parameters
+    ----------
+    counts: ConcordanceCounts
+        Raw concordance pair counts.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If there are no pairs available to estimate concordance.
+    """
+    if (
+        counts.concordant
+        + counts.discordant
+        + counts.risk_tie_pairs
+        + counts.time_tie_pairs
+        == 0
+    ):
         raise ValueError(
             "Data has no comparable pairs, cannot estimate concordance index."
         )
 
-    concordant = 0
-    discordant = 0
-    risk_tie_pairs = 0.0
-    numerator = 0.0
-    denominator = 0.0
-    for ind, mask in comparable.items():
-        est_i = estimate[order[ind]]
-        event_i = event_indicator[order[ind]]
-        # w_i = partial_weights[order[ind]] # change this
-        w_i = weight[ind]
-        weight_i = w_i[order[mask]]
 
-        est = estimate[order[mask]]
-
-        assert event_i, (
-            "got censored sample at index %d, but expected uncensored" % order[ind]
-        )
-
-        ties = np.absolute(est - est_i) <= tied_tol
-        # n_ties = ties.sum()
-        n_ties = np.dot(weight_i, ties.T)
-        # an event should have a higher score
-        con = est < est_i
-        # n_con = con[~ties].sum()
-        con[ties] = False
-        n_con = np.dot(weight_i, con.T)
-
-        # numerator += w_i * n_con + 0.5 * w_i * n_ties
-        # denominator += w_i * mask.sum()
-        numerator += n_con + 0.5 * n_ties
-        denominator += np.dot(w_i, mask.T)
-
-        risk_tie_pairs += n_ties
-        concordant += n_con
-        # discordant += est.size - n_con - n_ties
-        discordant += np.dot(w_i, mask.T) - n_con - n_ties
-
-    c_index = numerator / denominator
-    return c_index, concordant, discordant, risk_tie_pairs, time_tie_pairs
-
-
-def _get_comparable(
+def _right_censored_risk_counts(
     event_indicator: np.ndarray,
     event_time: np.ndarray,
-    order: np.ndarray,
-    partial_weights: np.ndarray = None,
-) -> tuple[dict, int, dict]:
-    """
-    Given the labels of the survival outcomes, get the comparable pairs.
-
-    This backbone of this function is borrowed from scikit-survival:
-    https://github.com/sebp/scikit-survival/blob/4e664d8e4fe5e5b55006e3913f2bbabcf2455496/sksurv/metrics.py#L57-L81
-    In here, we make modifications to the original function to calculates the weights for each pair.
-
-    All functions in scikit-survival are licensed under the GPLv3 License:
-    https://github.com/sebp/scikit-survival/blob/master/COPYING
+    estimate: np.ndarray,
+    sample_weights: Optional[np.ndarray] = None,
+    tied_tol: float = 1e-8,
+) -> ConcordanceCounts:
+    """Count right-censored comparable pairs for a risk score.
 
     Parameters
     ----------
     event_indicator: np.ndarray, shape = (n_samples,)
-        Binary event indicators: 1 denotes an observed event and 0 denotes a
-        censored observation.
+        Boolean event indicators, where True denotes an observed event.
     event_time: np.ndarray, shape = (n_samples,)
-        The true survival times.
-    order: np.ndarray, shape = (n_samples,)
-        The indices that would sort the event times.
-    partial_weights: np.ndarray, shape = (n_samples,), optional (default=None)
-        The partial weights for the censored samples.
+        Observed event or censoring times.
+    estimate: np.ndarray, shape = (n_samples,)
+        Risk scores. Higher scores indicate higher risk.
+    sample_weights: np.ndarray, shape = (n_samples,), optional
+        Optional symmetric sample weights. Pair weights are products of anchor
+        and candidate sample weights.
+    tied_tol: float, optional (default=1e-8)
+        Absolute tolerance for risk-score ties.
 
     Returns
     -------
-    comparable: dict
-        A dictionary where the keys are the indices of the samples with events, and the values are boolean masks
-        indicating which samples are comparable to the key sample.
-    time_tie_pairs: float
-        The number of weighted tied-time pairs between observed events.
-    weight: dict
-        A dictionary where the keys are the indices of the samples with events, and the values are the weights
-        for each comparable sample.
+    ConcordanceCounts
+        Raw concordance counts before tie-mode finalization. ``concordant``,
+        ``discordant``, and ``risk_tie_pairs`` count comparable pairs;
+        ``time_tie_pairs`` counts same-time event pairs.
     """
+    if sample_weights is None:
+        sample_weights = np.ones(event_time.shape[0], dtype=float)
 
-    if partial_weights is None:
-        partial_weights = np.ones_like(event_indicator, dtype=float)
-    n_samples = len(event_time)
-    time_tie_pairs = 0.0
-    comparable = {}
-    weight = {}
+    counts = ConcordanceCounts()
+    for block, later_samples in _iter_time_blocks(event_time):
+        event_anchors = block[event_indicator[block]]
+        if event_anchors.shape[0] == 0:
+            continue
 
-    i = 0
-    while i < n_samples - 1:
-        time_i = event_time[order[i]]
-        end = i + 1
+        # Same-time events are not comparable; same-time censored samples are.
+        counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
+        candidates = np.concatenate((block[~event_indicator[block]], later_samples))
+        if candidates.shape[0] == 0:
+            continue
+
+        for anchor_index in event_anchors:
+            pair_weights = sample_weights[anchor_index] * sample_weights[candidates]
+            counts += _count_directed_risk_pairs(
+                np.full(candidates.shape[0], anchor_index, dtype=int),
+                candidates,
+                estimate,
+                pair_weights=pair_weights,
+                tied_tol=tied_tol,
+            )
+
+    return counts
+
+
+def _margin_counts(
+    event_indicator: np.ndarray,
+    event_time: np.ndarray,
+    estimate: np.ndarray,
+    bg_event_time: np.ndarray,
+    partial_weights: np.ndarray,
+    tied_tol: float = 1e-8,
+) -> ConcordanceCounts:
+    """Count Margin concordance pairs from best-guess times.
+
+    Margin first scores all samples as events at their best-guess event times
+    with partial weights. Harrell-comparable observed pairs are then restored
+    to their original observed ordering at full weight.
+
+    Parameters
+    ----------
+    event_indicator: np.ndarray, shape = (n_samples,)
+        Boolean event indicators, where True denotes an observed event.
+    event_time: np.ndarray, shape = (n_samples,)
+        Observed event or censoring times.
+    estimate: np.ndarray, shape = (n_samples,)
+        Risk scores. Higher scores indicate higher risk.
+    bg_event_time: np.ndarray, shape = (n_samples,)
+        Best-guess event times for all samples.
+    partial_weights: np.ndarray, shape = (n_samples,)
+        Per-sample weights used for the best-guess baseline.
+    tied_tol: float, optional (default=1e-8)
+        Absolute tolerance for risk-score ties.
+
+    Returns
+    -------
+    ConcordanceCounts
+        Raw Margin concordance counts before tie-mode finalization.
+    """
+    counts = _right_censored_risk_counts(
+        np.ones_like(event_indicator, dtype=bool),
+        bg_event_time,
+        estimate,
+        sample_weights=partial_weights,
+        tied_tol=tied_tol,
+    )
+
+    for anchor_indices, candidate_indices in _iter_comparable_event_pairs(
+        event_indicator, event_time
+    ):
+        baseline_weights = (
+            partial_weights[anchor_indices] * partial_weights[candidate_indices]
+        )
+        anchor_before = bg_event_time[anchor_indices] < bg_event_time[candidate_indices]
+        candidate_before = (
+            bg_event_time[anchor_indices] > bg_event_time[candidate_indices]
+        )
+        tied_time = ~(anchor_before | candidate_before)
+
+        counts += _count_directed_risk_pairs(
+            anchor_indices[anchor_before],
+            candidate_indices[anchor_before],
+            estimate,
+            pair_weights=-baseline_weights[anchor_before],
+            tied_tol=tied_tol,
+        )
+        counts += _count_directed_risk_pairs(
+            candidate_indices[candidate_before],
+            anchor_indices[candidate_before],
+            estimate,
+            pair_weights=-baseline_weights[candidate_before],
+            tied_tol=tied_tol,
+        )
+        counts.time_tie_pairs -= baseline_weights[tied_time].sum()
+        counts += _count_directed_risk_pairs(
+            anchor_indices,
+            candidate_indices,
+            estimate,
+            pair_weights=np.ones(anchor_indices.shape[0], dtype=float),
+            tied_tol=tied_tol,
+        )
+
+    return counts
+
+
+def _count_directed_risk_pairs(
+    anchor_indices: np.ndarray,
+    candidate_indices: np.ndarray,
+    estimate: np.ndarray,
+    pair_weights: np.ndarray,
+    tied_tol: float = 1e-8,
+) -> ConcordanceCounts:
+    """Count concordance outcomes for directed risk-score pairs.
+
+    Parameters
+    ----------
+    anchor_indices: np.ndarray, shape = (n_pairs,)
+        Sample indices for the earlier or anchor side of each pair.
+    candidate_indices: np.ndarray, shape = (n_pairs,)
+        Sample indices for the later or candidate side of each pair.
+    estimate: np.ndarray, shape = (n_samples,)
+        Risk scores. Higher scores indicate higher risk.
+    pair_weights: np.ndarray, shape = (n_pairs,)
+        Weight for each directed pair.
+    tied_tol: float, optional (default=1e-8)
+        Absolute tolerance for risk-score ties.
+
+    Returns
+    -------
+    ConcordanceCounts
+        Raw concordance counts for the supplied directed pairs.
+    """
+    if anchor_indices.shape[0] == 0:
+        return ConcordanceCounts()
+
+    risk_diff = estimate[candidate_indices] - estimate[anchor_indices]
+    tied = np.absolute(risk_diff) <= tied_tol
+    concordant = (risk_diff < 0) & ~tied
+
+    concordant_weight = pair_weights[concordant].sum()
+    risk_tie_weight = pair_weights[tied].sum()
+    return ConcordanceCounts(
+        concordant=concordant_weight,
+        discordant=pair_weights.sum() - concordant_weight - risk_tie_weight,
+        risk_tie_pairs=risk_tie_weight,
+    )
+
+
+def _iter_comparable_event_pairs(
+    event_indicator: np.ndarray,
+    event_time: np.ndarray,
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Yield directed comparable event pairs in sample-index coordinates.
+
+    Parameters
+    ----------
+    event_indicator: np.ndarray, shape = (n_samples,)
+        Boolean event indicators, where True denotes an observed event.
+    event_time: np.ndarray, shape = (n_samples,)
+        Observed event or censoring times.
+
+    Yields
+    ------
+    anchor_indices: np.ndarray, shape = (n_pairs,)
+        Repeated sample indices for the observed-event anchor side of each pair.
+    candidate_indices: np.ndarray, shape = (n_pairs,)
+        Sample indices that are either later in observed time or censored at
+        the same observed time as the anchor.
+    """
+    for block, later_samples in _iter_time_blocks(event_time):
+        event_anchors = block[event_indicator[block]]
+        if event_anchors.shape[0] > 0:
+            same_time_censored = block[~event_indicator[block]]
+            candidates = np.concatenate((same_time_censored, later_samples))
+            for anchor_index in event_anchors:
+                if candidates.shape[0] > 0:
+                    yield np.full(candidates.shape[0], anchor_index, dtype=int), candidates
+
+
+def _iter_time_blocks(event_time: np.ndarray) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Yield equal-time sample blocks and the samples with later observed times.
+
+    Parameters
+    ----------
+    event_time: np.ndarray, shape = (n_samples,)
+        Observed event or censoring times.
+
+    Yields
+    ------
+    block: np.ndarray
+        Sample indices with the same observed time.
+    later_samples: np.ndarray
+        Sample indices whose observed time is greater than the block time.
+    """
+    order = np.argsort(event_time, kind="stable")
+    n_samples = order.shape[0]
+
+    start = 0
+    while start < n_samples:
+        end = start + 1
+        time_i = event_time[order[start]]
         while end < n_samples and event_time[order[end]] == time_i:
             end += 1
 
-        # check for tied event times
-        event_at_same_time = event_indicator[order[i:end]]
-        censored_at_same_time = ~event_at_same_time
+        yield order[start:end], order[end:]
+        start = end
 
-        for j in range(i, end):
-            if event_indicator[order[j]]:
-                mask = np.zeros(n_samples, dtype=bool)
-                mask[end:] = True
-                # an event is comparable to censored samples at same time point
-                mask[i:end] = censored_at_same_time
-                comparable[j] = mask
-                event_at_later_same_time = event_indicator[order[j + 1 : end]]
-                time_tie_pairs += (
-                    partial_weights[order[j]]
-                    * partial_weights[order[j + 1 : end]][event_at_later_same_time]
-                ).sum()
-                weight[j] = partial_weights[order] * partial_weights[order[j]]
-        i = end
 
-    return comparable, time_tie_pairs, weight
+def _same_time_pair_weight(sample_weights: np.ndarray) -> float:
+    """Return the total pair weight within one same-time event block.
+
+    Parameters
+    ----------
+    sample_weights: np.ndarray
+        Per-sample weights for samples in the same event-time block.
+
+    Returns
+    -------
+    float
+        The sum of pairwise weight products for all unique pairs in the block.
+    """
+    if sample_weights.shape[0] < 2:
+        return 0.0
+    total_weight = sample_weights.sum()
+    return 0.5 * (total_weight * total_weight - np.dot(sample_weights, sample_weights))
 
 
 def _get_comparable_ic(

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -6,6 +6,7 @@ from typing import Iterator, Optional, Tuple
 import numpy as np
 
 from SurvivalEVAL.NonparametricEstimator.SingleEvent import (
+    KaplanMeier,
     KaplanMeierArea,
     TurnbullEstimatorLifelines,
 )
@@ -60,6 +61,7 @@ def concordance(
     train_event_indicators: Optional[np.ndarray] = None,
     method: str = "Harrell",
     ties: str = "Risk",
+    tau: Optional[float] = None,
 ) -> tuple[float, float, float]:
     """
     Calculate the concordance index between the predicted survival times and the true survival times.
@@ -73,17 +75,26 @@ def concordance(
     event_indicators: np.ndarray, shape = (n_samples,)
         Binary event indicators: 1 denotes an observed event and 0 denotes a
         censored observation.
-    train_event_times: np.ndarray, shape = (n_train_samples,)
-        The true survival times of the training set.
-    train_event_indicators: np.ndarray, shape = (n_train_samples,)
+    train_event_times: np.ndarray, shape = (n_train_samples,), optional
+        The true survival times of the training set. Required for "Uno",
+        "IPCW", and "Margin".
+    train_event_indicators: np.ndarray, shape = (n_train_samples,), optional
         Binary training-set event indicators: 1 denotes an observed event and
-        0 denotes a censored observation.
+        0 denotes a censored observation. Required for "Uno", "IPCW", and
+        "Margin".
     method: str, optional (default="Harrell")
         A string indicating the method for constructing the pairs of samples.
-        "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
-        event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
-        "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
-        will be calculated and used to construct the pairs.
+        Options are "Harrell" (default), "Naive", "Uno", "IPCW", or "Margin".
+        "Harrell": comparable pairs are anchored by samples with observed
+        events. If sample i has an observed event at time t_i, it is compared
+        with samples whose observed event/censoring time is greater than t_i.
+        "Naive": alias of "Harrell".
+        "Uno": Harrell-style comparable pairs weighted by inverse probability
+        of censoring weights from the training data.
+        "IPCW": alias of "Uno".
+        "Margin": the pairs are constructed between all samples. A best-guess
+        time for the censored samples will be calculated and used to construct
+        the pairs.
     ties: str, optional (default="Risk")
         A string indicating the way ties should be handled.
         Options: "None", "Time", "Risk" (default), or "All"
@@ -93,6 +104,10 @@ def concordance(
         "All" includes all ties.
         Note the concordance calculation is given by
         (Concordant Pairs + (Number of Ties/2))/(Concordant Pairs + Discordant Pairs + Number of Ties).
+    tau: float, optional (default=None)
+        Truncation time. If provided, only pairs whose effective earlier or
+        anchor time is strictly before ``tau`` are counted. If None, no
+        truncation is applied.
 
     Returns
     -------
@@ -116,9 +131,37 @@ def concordance(
     method = method.lower()
     ties = ties.lower()
 
-    if method == "harrell":
+    if method == "harrell" or method == "naive":
         risks = -1 * predicted_times
-        counts = _right_censored_risk_counts(event_indicators, event_times, risks)
+        counts = _right_censored_risk_counts(
+            event_indicators, event_times, risks, tau=tau
+        )
+    elif method == "uno" or method == "ipcw":
+        if train_event_times is None or train_event_indicators is None:
+            error = "If 'Uno' or 'IPCW' is chosen, training set information must be provided."
+            raise ValueError(error)
+
+        train_event_indicators = train_event_indicators.astype(bool)
+
+        censoring_model = KaplanMeier(train_event_times, ~train_event_indicators)
+        censoring_survival = censoring_model.predict(event_times)
+        observed_anchors = event_indicators & _is_before_tau(event_times, tau)
+        if np.any(censoring_survival[observed_anchors] <= 0):
+            raise ValueError(
+                "Censoring survival probability is zero for at least one observed event; "
+                "cannot estimate Uno's concordance."
+            )
+
+        ipcw_weights = np.zeros_like(event_times, dtype=float)
+        ipcw_weights[observed_anchors] = 1 / censoring_survival[observed_anchors]
+        counts = _right_censored_risk_counts(
+            event_indicators,
+            event_times,
+            -1 * predicted_times,
+            sample_weights=ipcw_weights,
+            anchor_pair_weights=np.square(ipcw_weights),
+            tau=tau,
+        )
     elif method == "margin":
         if train_event_times is None or train_event_indicators is None:
             error = "If 'Margin' is chosen, training set information must be provided."
@@ -153,6 +196,7 @@ def concordance(
             estimate=risks,
             bg_event_time=bg_event_times,
             partial_weights=partial_weights,
+            tau=tau,
         )
     else:
         raise TypeError("Method for calculating concordance is unrecognized.")
@@ -241,6 +285,8 @@ def _right_censored_risk_counts(
     event_time: np.ndarray,
     estimate: np.ndarray,
     sample_weights: Optional[np.ndarray] = None,
+    anchor_pair_weights: Optional[np.ndarray] = None,
+    tau: Optional[float] = None,
     tied_tol: float = 1e-8,
 ) -> ConcordanceCounts:
     """Count right-censored comparable pairs for a risk score.
@@ -255,7 +301,13 @@ def _right_censored_risk_counts(
         Risk scores. Higher scores indicate higher risk.
     sample_weights: np.ndarray, shape = (n_samples,), optional
         Optional symmetric sample weights. Pair weights are products of anchor
-        and candidate sample weights.
+        and candidate sample weights unless ``anchor_pair_weights`` is provided.
+    anchor_pair_weights: np.ndarray, shape = (n_samples,), optional
+        Optional per-anchor pair weights. If provided, every comparable pair
+        anchored by sample ``i`` receives ``anchor_pair_weights[i]``.
+    tau: float, optional (default=None)
+        Truncation time. If provided, only event anchors whose observed time is
+        strictly before ``tau`` are counted. If None, no truncation is applied.
     tied_tol: float, optional (default=1e-8)
         Absolute tolerance for risk-score ties.
 
@@ -271,21 +323,31 @@ def _right_censored_risk_counts(
 
     counts = ConcordanceCounts()
     for block, later_samples in _iter_time_blocks(event_time):
+        if tau is not None and event_time[block[0]] >= tau:
+            break
+
         event_anchors = block[event_indicator[block]]
         if event_anchors.shape[0] == 0:
             continue
 
         # Same-time events are not comparable; same-time censored samples are.
         counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
-        candidates = np.concatenate((block[~event_indicator[block]], later_samples))
-        if candidates.shape[0] == 0:
+        candidate_indices = np.concatenate((block[~event_indicator[block]], later_samples))
+        if candidate_indices.shape[0] == 0:
             continue
 
         for anchor_index in event_anchors:
-            pair_weights = sample_weights[anchor_index] * sample_weights[candidates]
+            if anchor_pair_weights is None:
+                pair_weights = sample_weights[anchor_index] * sample_weights[candidate_indices]
+            else:
+                pair_weights = np.full(
+                    candidate_indices.shape[0],
+                    anchor_pair_weights[anchor_index],
+                    dtype=float,
+                )
             counts += _count_directed_risk_pairs(
-                np.full(candidates.shape[0], anchor_index, dtype=int),
-                candidates,
+                np.full(candidate_indices.shape[0], anchor_index, dtype=int),
+                candidate_indices,
                 estimate,
                 pair_weights=pair_weights,
                 tied_tol=tied_tol,
@@ -300,6 +362,7 @@ def _margin_counts(
     estimate: np.ndarray,
     bg_event_time: np.ndarray,
     partial_weights: np.ndarray,
+    tau: Optional[float] = None,
     tied_tol: float = 1e-8,
 ) -> ConcordanceCounts:
     """Count Margin concordance pairs from best-guess times.
@@ -320,6 +383,11 @@ def _margin_counts(
         Best-guess event times for all samples.
     partial_weights: np.ndarray, shape = (n_samples,)
         Per-sample weights used for the best-guess baseline.
+    tau: float, optional (default=None)
+        Truncation time. Best-guess baseline pairs use the best-guess earlier
+        time, while observed-pair replacements use the observed event anchor
+        time. In both cases the effective time must be strictly before ``tau``.
+        If None, no truncation is applied.
     tied_tol: float, optional (default=1e-8)
         Absolute tolerance for risk-score ties.
 
@@ -333,6 +401,7 @@ def _margin_counts(
         bg_event_time,
         estimate,
         sample_weights=partial_weights,
+        tau=tau,
         tied_tol=tied_tol,
     )
 
@@ -347,31 +416,48 @@ def _margin_counts(
             bg_event_time[anchor_indices] > bg_event_time[candidate_indices]
         )
         tied_time = ~(anchor_before | candidate_before)
+        baseline_anchor_before_tau = _is_before_tau(bg_event_time[anchor_indices], tau)
+        baseline_candidate_before_tau = _is_before_tau(
+            bg_event_time[candidate_indices], tau
+        )
+        tied_time_before_tau = baseline_anchor_before_tau
+
+        anchor_baseline_included = anchor_before & baseline_anchor_before_tau
+        candidate_baseline_included = candidate_before & baseline_candidate_before_tau
+        tied_time_baseline_included = tied_time & tied_time_before_tau
+        observed_replacement_included = _is_before_tau(event_time[anchor_indices], tau)
 
         counts += _count_directed_risk_pairs(
-            anchor_indices[anchor_before],
-            candidate_indices[anchor_before],
+            anchor_indices[anchor_baseline_included],
+            candidate_indices[anchor_baseline_included],
             estimate,
-            pair_weights=-baseline_weights[anchor_before],
+            pair_weights=-baseline_weights[anchor_baseline_included],
             tied_tol=tied_tol,
         )
         counts += _count_directed_risk_pairs(
-            candidate_indices[candidate_before],
-            anchor_indices[candidate_before],
+            candidate_indices[candidate_baseline_included],
+            anchor_indices[candidate_baseline_included],
             estimate,
-            pair_weights=-baseline_weights[candidate_before],
+            pair_weights=-baseline_weights[candidate_baseline_included],
             tied_tol=tied_tol,
         )
-        counts.time_tie_pairs -= baseline_weights[tied_time].sum()
+        counts.time_tie_pairs -= baseline_weights[tied_time_baseline_included].sum()
         counts += _count_directed_risk_pairs(
-            anchor_indices,
-            candidate_indices,
+            anchor_indices[observed_replacement_included],
+            candidate_indices[observed_replacement_included],
             estimate,
-            pair_weights=np.ones(anchor_indices.shape[0], dtype=float),
+            pair_weights=np.ones(observed_replacement_included.sum(), dtype=float),
             tied_tol=tied_tol,
         )
 
     return counts
+
+
+def _is_before_tau(times: np.ndarray, tau: Optional[float]) -> np.ndarray:
+    """Return a boolean mask for times that pass the strict tau truncation."""
+    if tau is None:
+        return np.ones(times.shape, dtype=bool)
+    return times < tau
 
 
 def _count_directed_risk_pairs(
@@ -442,10 +528,10 @@ def _iter_comparable_event_pairs(
         event_anchors = block[event_indicator[block]]
         if event_anchors.shape[0] > 0:
             same_time_censored = block[~event_indicator[block]]
-            candidates = np.concatenate((same_time_censored, later_samples))
+            candidate_indices = np.concatenate((same_time_censored, later_samples))
             for anchor_index in event_anchors:
-                if candidates.shape[0] > 0:
-                    yield np.full(candidates.shape[0], anchor_index, dtype=int), candidates
+                if candidate_indices.shape[0] > 0:
+                    yield np.full(candidate_indices.shape[0], anchor_index, dtype=int), candidate_indices
 
 
 def _iter_time_blocks(event_time: np.ndarray) -> Iterator[tuple[np.ndarray, np.ndarray]]:

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -226,7 +226,9 @@ def concordance(
     return _finalize_counts(counts, ties)
 
 
-def _finalize_counts(counts: ConcordanceCounts, ties: str) -> tuple[float, float, float]:
+def _finalize_counts(
+    counts: ConcordanceCounts, ties: str
+) -> tuple[float, float, float]:
     """Apply the requested tie policy to raw concordance counts.
 
     Parameters
@@ -353,13 +355,17 @@ def _right_censored_risk_counts(
 
         # Same-time events are not comparable; same-time censored samples are.
         counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
-        candidate_indices = np.concatenate((block[~event_indicator[block]], later_samples))
+        candidate_indices = np.concatenate(
+            (block[~event_indicator[block]], later_samples)
+        )
         if candidate_indices.shape[0] == 0:
             continue
 
         for anchor_index in event_anchors:
             if anchor_pair_weights is None:
-                pair_weights = sample_weights[anchor_index] * sample_weights[candidate_indices]
+                pair_weights = (
+                    sample_weights[anchor_index] * sample_weights[candidate_indices]
+                )
             else:
                 pair_weights = np.full(
                     candidate_indices.shape[0],
@@ -375,6 +381,7 @@ def _right_censored_risk_counts(
             )
 
     return counts
+
 
 def _margin_counts(
     event_indicator: np.ndarray,
@@ -551,10 +558,14 @@ def _iter_comparable_event_pairs(
             candidate_indices = np.concatenate((same_time_censored, later_samples))
             for anchor_index in event_anchors:
                 if candidate_indices.shape[0] > 0:
-                    yield np.full(candidate_indices.shape[0], anchor_index, dtype=int), candidate_indices
+                    yield np.full(
+                        candidate_indices.shape[0], anchor_index, dtype=int
+                    ), candidate_indices
 
 
-def _iter_time_blocks(event_time: np.ndarray) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+def _iter_time_blocks(
+    event_time: np.ndarray,
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
     """Yield equal-time sample blocks and the samples with later observed times.
 
     Parameters

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -148,19 +148,23 @@ def concordance(
         observed_anchors = event_indicators & _is_before_tau(event_times, tau)
 
         # Uno/IPCW only needs positive censoring survival for anchors whose
-        # weights can actually be used. Every non-final event-time block has
-        # later samples as candidates. In the final observed-time block, an
-        # event anchor still contributes if there is a same-time censored sample
-        # or another same-time event for the time-tie count. The only observed
-        # anchor that cannot contribute is a singleton event in the final block,
-        # so exclude just that case from the zero-survival check and weight
+        # weights can affect the selected concordance result. Every non-final
+        # event-time block has later samples as candidates. In the final block,
+        # event anchors still contribute through same-time censored candidates;
+        # event-event time ties contribute only when the requested tie policy
+        # keeps time ties. Otherwise final events have no effect on the returned
+        # index, so exclude them from the zero-survival check and weight
         # assignment.
         final_time = np.max(event_times)
         final_block = event_times == final_time
         final_events = final_block & event_indicators
         final_event_count = np.count_nonzero(final_events)
         final_has_censored_candidate = np.any(final_block & ~event_indicators)
-        if final_event_count == 1 and not final_has_censored_candidate:
+        final_time_ties_counted = ties in {"time", "all"}
+        final_events_contribute = final_has_censored_candidate or (
+            final_time_ties_counted and final_event_count > 1
+        )
+        if not final_events_contribute:
             observed_anchors[final_events] = False
 
         if np.any(censoring_survival[observed_anchors] <= 0):

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -609,16 +609,16 @@ class SurvivalEvaluator:
         return fig, ax
 
     def concordance(
-        self, ties: str = "None", method: str = "Harrell"
+        self, ties: str = "Risk", method: str = "Harrell"
     ) -> tuple[float, float, float]:
         """
         Calculate the concordance index between the predicted survival times and the true survival times.
 
         Parameters
         ----------
-        ties: str, default = "None"
+        ties: str, default = "Risk"
             A string indicating the way ties should be handled.
-            Options: "None" (default), "Time", "Risk", or "All"
+            Options: "None", "Time", "Risk" (default), or "All"
             "None" will throw out all ties in true survival time and all ties in predict survival times (risk scores).
             "Time" includes ties in true survival time but removes ties in predict survival times (risk scores).
             "Risk" includes ties in predict survival times (risk scores) but not in true survival time.
@@ -1755,16 +1755,16 @@ class PointEvaluator:
         self._pred_times = pred_times
 
     def concordance(
-        self, ties: str = "None", method: str = "Harrell"
+        self, ties: str = "Risk", method: str = "Harrell"
     ) -> tuple[float, float, int]:
         """
         Calculate the concordance index between the predicted survival times and the true survival times.
 
         Parameters
         ----------
-        ties: str, default = "None"
+        ties: str, default = "Risk"
             A string indicating the way ties should be handled.
-            Options: "None" (default), "Time", "Risk", or "All"
+            Options: "None", "Time", "Risk" (default), or "All"
             "None" will throw out all ties in true survival time and all ties in predict survival times (risk scores).
             "Time" includes ties in true survival time but removes ties in predict survival times (risk scores).
             "Risk" includes ties in predict survival times (risk scores) but not in true survival time.

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -628,11 +628,8 @@ class SurvivalEvaluator:
         method: str, default = "Harrell"
             A string indicating the method for constructing the pairs of samples.
             Options: "Harrell" (default) or "Margin"
-            "Harrell": the pairs are constructed by comparing the predicted survival time of each sample with the
-            event time of all other samples. The pairs are only constructed between samples with comparable
-            event times. For example, if i-th sample has a censor time of 10, then the pairs are constructed by
-            comparing the predicted survival time of sample i with the event time of all samples with event
-            time of 10 or less.
+            "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
+            event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
             "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
             will be calculated and used to construct the pairs.
         :return: (float, float, int)
@@ -1774,11 +1771,8 @@ class PointEvaluator:
         method: str, default = "Harrell"
             A string indicating the method for constructing the pairs of samples.
             Options: "Harrell" (default) or "Margin"
-            "Harrell": the pairs are constructed by comparing the predicted survival time of each sample with the
-            event time of all other samples. The pairs are only constructed between samples with comparable
-            event times. For example, if i-th sample has a censor time of 10, then the pairs are constructed by
-            comparing the predicted survival time of sample i with the event time of all samples with event
-            time of 10 or less.
+            "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
+            event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
             "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
             will be calculated and used to construct the pairs.
 

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -609,7 +609,10 @@ class SurvivalEvaluator:
         return fig, ax
 
     def concordance(
-        self, ties: str = "Risk", method: str = "Harrell"
+        self,
+        ties: str = "Risk",
+        method: str = "Harrell",
+        tau: Optional[Numeric] = None,
     ) -> tuple[float, float, float]:
         """
         Calculate the concordance index between the predicted survival times and the true survival times.
@@ -627,12 +630,23 @@ class SurvivalEvaluator:
             (Concordant Pairs + (Number of Ties/2))/(Concordant Pairs + Discordant Pairs + Number of Ties).
         method: str, default = "Harrell"
             A string indicating the method for constructing the pairs of samples.
-            Options: "Harrell" (default) or "Margin"
-            "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
-            event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
-            "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
-            will be calculated and used to construct the pairs.
-        :return: (float, float, int)
+            Options are "Harrell" (default), "Naive", "Uno", "IPCW", or "Margin".
+            "Harrell": comparable pairs are anchored by samples with observed
+            events. If sample i has an observed event at time t_i, it is compared
+            with samples whose observed event/censoring time is greater than t_i.
+            "Naive": alias of "Harrell".
+            "Uno": Harrell-style comparable pairs weighted by inverse probability
+            of censoring weights from the training data.
+            "IPCW": alias of "Uno".
+            "Margin": the pairs are constructed between all samples. A best-guess
+            time for the censored samples will be calculated and used to construct
+            the pairs. "Uno", "IPCW", and "Margin" require training set
+            information.
+        tau: float, optional (default=None)
+            Truncation time. If provided, only pairs whose effective earlier or
+            anchor time is strictly before ``tau`` are counted. If None, no
+            truncation is applied.
+        :return: (float, float, float)
             The concordance index, the number of concordant pairs, and the number of total pairs.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
@@ -640,8 +654,8 @@ class SurvivalEvaluator:
         if self._NO_CENSOR:
             method = "harrell"
 
-        if method == "margin":
-            self._error_trainset("margin concordance")
+        if method in {"margin", "uno", "ipcw"}:
+            self._error_trainset(f"{method} concordance")
 
         return concordance(
             predicted_times=self.predicted_event_times,
@@ -651,11 +665,13 @@ class SurvivalEvaluator:
             train_event_indicators=self.train_event_indicators,
             method=method,
             ties=ties,
+            tau=tau,
         )
 
     def auc(self, target_time: Optional[Numeric] = None) -> float:
         """
-        Calculate the area under the ROC curve (AUC/AUROC) score at a given time point from the predicted survival curve.
+        Calculate the area under the ROC curve (AUC/AUROC) score at a given
+        time point from the predicted survival curve.
 
         Parameters
         ----------
@@ -688,7 +704,8 @@ class SurvivalEvaluator:
 
     def auroc(self, target_time: Optional[Numeric] = None):
         """
-        Calculate the area under the ROC curve (AUC/AUROC) score at a given time point from the predicted survival curve.
+        Calculate the area under the ROC curve (AUC/AUROC) score at a given
+        time point from the predicted survival curve.
 
         Alias for the '.auc()' method.
         Parameters
@@ -1752,8 +1769,11 @@ class PointEvaluator:
         self._pred_times = pred_times
 
     def concordance(
-        self, ties: str = "Risk", method: str = "Harrell"
-    ) -> tuple[float, float, int]:
+        self,
+        ties: str = "Risk",
+        method: str = "Harrell",
+        tau: Optional[Numeric] = None,
+    ) -> tuple[float, float, float]:
         """
         Calculate the concordance index between the predicted survival times and the true survival times.
 
@@ -1770,11 +1790,22 @@ class PointEvaluator:
             (Concordant Pairs + (Number of Ties/2))/(Concordant Pairs + Discordant Pairs + Number of Ties).
         method: str, default = "Harrell"
             A string indicating the method for constructing the pairs of samples.
-            Options: "Harrell" (default) or "Margin"
-            "Harrell": comparable pairs are anchored by samples with observed events. If sample i has an observed
-            event at time t_i, it is compared with samples whose observed event/censoring time is greater than t_i.
-            "Margin": the pairs are constructed between all samples. A best-guess time for the censored samples
-            will be calculated and used to construct the pairs.
+            Options are "Harrell" (default), "Naive", "Uno", "IPCW", or "Margin".
+            "Harrell": comparable pairs are anchored by samples with observed
+            events. If sample i has an observed event at time t_i, it is compared
+            with samples whose observed event/censoring time is greater than t_i.
+            "Naive": alias of "Harrell".
+            "Uno": Harrell-style comparable pairs weighted by inverse probability
+            of censoring weights from the training data.
+            "IPCW": alias of "Uno".
+            "Margin": the pairs are constructed between all samples. A best-guess
+            time for the censored samples will be calculated and used to construct
+            the pairs. "Uno", "IPCW", and "Margin" require training set
+            information.
+        tau: float, optional (default=None)
+            Truncation time. If provided, only pairs whose effective earlier or
+            anchor time is strictly before ``tau`` are counted. If None, no
+            truncation is applied.
 
         Returns
         -------
@@ -1782,7 +1813,7 @@ class PointEvaluator:
             The concordance index, which is the proportion of concordant pairs among all pairs.
         concordant_pairs: float
             The number of concordant pairs.
-        total_pairs: int
+        total_pairs: float
             The total number of comparable pairs considered in the concordance calculation.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
@@ -1790,8 +1821,8 @@ class PointEvaluator:
         if self._NO_CENSOR:
             method = "harrell"
 
-        if method == "margin":
-            self._error_trainset("margin concordance")
+        if method in {"margin", "uno", "ipcw"}:
+            self._error_trainset(f"{method} concordance")
 
         return concordance(
             predicted_times=self._pred_times,
@@ -1801,6 +1832,7 @@ class PointEvaluator:
             train_event_indicators=self.train_event_indicators,
             method=method,
             ties=ties,
+            tau=tau,
         )
 
     def mae(

--- a/SurvivalEVAL/__init__.py
+++ b/SurvivalEVAL/__init__.py
@@ -6,7 +6,11 @@ from SurvivalEVAL.Evaluations.BrierScore import (
     brier_score_ic,
     single_brier_score,
 )
-from SurvivalEVAL.Evaluations.Concordance import concordance, concordance_ic
+from SurvivalEVAL.Evaluations.Concordance import (
+    ConcordanceCounts,
+    concordance,
+    concordance_ic,
+)
 from SurvivalEVAL.Evaluations.DistributionCalibration import (
     coverage_ic,
     d_cal_ic,
@@ -57,6 +61,7 @@ __all__ = [
     "brier_multiple_points_ic",
     "concordance",
     "concordance_ic",
+    "ConcordanceCounts",
     "coverage_ic",
     "d_calibration",
     "km_calibration",

--- a/SurvivalEVAL/version.py
+++ b/SurvivalEVAL/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -460,6 +460,33 @@ def test_uno_ignores_zero_censoring_survival_for_non_contributing_final_anchor()
     np.testing.assert_allclose(actual, (1.0, 3.0, 3.0))
 
 
+@pytest.mark.parametrize("method", ["Uno", "IPCW"])
+def test_uno_ignores_zero_censoring_survival_for_discarded_final_time_ties(method):
+    predicted_times = np.array([1.0, 2.0, 3.0])
+    event_times = np.array([1.0, 2.0, 2.0])
+    event_indicators = np.array([1, 1, 1])
+    train_event_times = np.array([1.0, 2.0])
+    train_event_indicators = np.array([1, 0])
+    kwargs = {
+        "predicted_times": predicted_times,
+        "event_times": event_times,
+        "event_indicators": event_indicators,
+        "train_event_times": train_event_times,
+        "train_event_indicators": train_event_indicators,
+        "method": method,
+    }
+
+    default_ties = concordance(**kwargs)
+    no_ties = concordance(**kwargs, ties="None")
+
+    np.testing.assert_allclose(default_ties, (1.0, 2.0, 2.0))
+    np.testing.assert_allclose(no_ties, (1.0, 2.0, 2.0))
+    with pytest.raises(ValueError):
+        concordance(**kwargs, ties="Time")
+    with pytest.raises(ValueError):
+        concordance(**kwargs, ties="All")
+
+
 def test_margin_concordance_sorts_pairs_by_best_guess_times():
     event_indicators = np.array([True, False, True])
     event_times = np.array([1.0, 2.0, 3.0])

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -47,6 +47,57 @@ def test_point_evaluator_concordance_default_uses_standard_harrell_tie_handling(
     assert np.isclose(c_default, 5.0 / 6.0)
 
 
+def test_concordance_tie_modes_separate_risk_time_and_censoring_ties():
+    # This example has 8 concordant pairs, 3 discordant pairs, 5 comparable
+    # risk ties, and 2 event-event time ties. It also includes event-censored
+    # same-time pairs and censored-censored same-time pairs, which must not be
+    # counted as time ties.
+    predicted_times = np.array([1.0, 1.0, 1.0, 3.0, 0.0, 1.0, 4.0, 2.0])
+    event_times = np.array([1.0, 1.0, 2.0, 1.0, 3.0, 2.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1, 0, 1, 0, 0, 1])
+
+    c_none, concordant_none, total_none = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        ties="None",
+    )
+    c_risk, concordant_risk, total_risk = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        ties="Risk",
+    )
+    c_time, concordant_time, total_time = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        ties="Time",
+    )
+    c_all, concordant_all, total_all = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        ties="All",
+    )
+
+    assert np.isclose(c_none, 8.0 / 11.0)
+    assert np.isclose(concordant_none, 8.0)
+    assert np.isclose(total_none, 11.0)
+
+    assert np.isclose(c_risk, 10.5 / 16.0)
+    assert np.isclose(concordant_risk, 10.5)
+    assert np.isclose(total_risk, 16.0)
+
+    assert np.isclose(c_time, 9.0 / 13.0)
+    assert np.isclose(concordant_time, 9.0)
+    assert np.isclose(total_time, 13.0)
+
+    assert np.isclose(c_all, 11.5 / 18.0)
+    assert np.isclose(concordant_all, 11.5)
+    assert np.isclose(total_all, 18.0)
+
+
 def test_get_comparable_ic_returns_directed_precedence_relation():
     left = np.array([0.0, 2.0, 4.0])
     right = np.array([1.0, 3.0, 5.0])

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -1,7 +1,104 @@
 import numpy as np
+import pytest
 
 from SurvivalEVAL import PointEvaluator
-from SurvivalEVAL.Evaluations.Concordance import _get_comparable_ic, concordance
+from SurvivalEVAL.Evaluations.Concordance import (
+    ConcordanceCounts,
+    _finalize_counts,
+    _get_comparable_ic,
+    _margin_counts,
+    _right_censored_risk_counts,
+    concordance,
+)
+
+
+def _add_directed_pair(counts, risks, anchor, candidate, weight=1.0, tied_tol=1e-8):
+    risk_diff = risks[candidate] - risks[anchor]
+    if abs(risk_diff) <= tied_tol:
+        counts.risk_tie_pairs += weight
+    elif risk_diff < 0:
+        counts.concordant += weight
+    else:
+        counts.discordant += weight
+
+
+def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=None):
+    if sample_weights is None:
+        sample_weights = np.ones(event_times.shape[0], dtype=float)
+    counts = ConcordanceCounts()
+
+    for i in range(event_times.shape[0]):
+        for j in range(i + 1, event_times.shape[0]):
+            if (
+                event_indicators[i]
+                and event_indicators[j]
+                and event_times[i] == event_times[j]
+            ):
+                counts.time_tie_pairs += sample_weights[i] * sample_weights[j]
+
+    for i in range(event_times.shape[0]):
+        if not event_indicators[i]:
+            continue
+        for j in range(event_times.shape[0]):
+            if i == j:
+                continue
+            is_later = event_times[j] > event_times[i]
+            is_same_time_censored = (
+                event_times[j] == event_times[i] and not event_indicators[j]
+            )
+            if is_later or is_same_time_censored:
+                _add_directed_pair(
+                    counts,
+                    risks,
+                    anchor=i,
+                    candidate=j,
+                    weight=sample_weights[i] * sample_weights[j],
+                )
+
+    return counts
+
+
+def _brute_margin_counts(
+    event_indicators, event_times, risks, bg_event_times, partial_weights
+):
+    counts = _brute_harrell_counts(
+        np.ones_like(event_indicators, dtype=bool),
+        bg_event_times,
+        risks,
+        sample_weights=partial_weights,
+    )
+
+    for i in range(event_times.shape[0]):
+        if not event_indicators[i]:
+            continue
+        for j in range(event_times.shape[0]):
+            if i == j:
+                continue
+            is_later = event_times[j] > event_times[i]
+            is_same_time_censored = (
+                event_times[j] == event_times[i] and not event_indicators[j]
+            )
+            if not (is_later or is_same_time_censored):
+                continue
+
+            baseline_weight = partial_weights[i] * partial_weights[j]
+            if bg_event_times[i] < bg_event_times[j]:
+                _add_directed_pair(counts, risks, i, j, weight=-baseline_weight)
+            elif bg_event_times[i] > bg_event_times[j]:
+                _add_directed_pair(counts, risks, j, i, weight=-baseline_weight)
+            else:
+                counts.time_tie_pairs -= baseline_weight
+
+            _add_directed_pair(counts, risks, i, j, weight=1.0)
+
+    return counts
+
+
+def _assert_counts_close(actual, expected):
+    assert np.isclose(actual.concordant, expected.concordant)
+    assert np.isclose(actual.discordant, expected.discordant)
+    assert np.isclose(actual.risk_tie_pairs, expected.risk_tie_pairs)
+    assert np.isclose(actual.time_tie_pairs, expected.time_tie_pairs)
 
 
 def test_concordance_default_gives_half_credit_to_tied_risk_predictions():
@@ -96,6 +193,145 @@ def test_concordance_tie_modes_separate_risk_time_and_censoring_ties():
     assert np.isclose(c_all, 11.5 / 18.0)
     assert np.isclose(concordant_all, 11.5)
     assert np.isclose(total_all, 18.0)
+
+
+@pytest.mark.parametrize("ties", ["None", "Risk", "Time", "All"])
+def test_harrell_concordance_matches_brute_force_edge_cases(ties):
+    cases = [
+        (
+            np.array([1.0, 1.0, 1.0, 3.0, 0.0, 1.0, 4.0, 2.0]),
+            np.array([1.0, 1.0, 2.0, 1.0, 3.0, 2.0, 2.0, 3.0]),
+            np.array([1, 1, 1, 0, 1, 0, 0, 1]),
+        ),
+        (
+            np.array([2.0, 2.0, 1.0, 4.0, 3.0]),
+            np.array([1.0, 2.0, 2.0, 2.0, 4.0]),
+            np.array([1, 1, 0, 1, 0]),
+        ),
+    ]
+
+    for predicted_times, event_times, event_indicators in cases:
+        risks = -predicted_times
+        expected_counts = _brute_harrell_counts(event_indicators, event_times, risks)
+        expected = _finalize_counts(expected_counts, ties)
+        actual = concordance(
+            predicted_times,
+            event_times,
+            event_indicators,
+            method="Harrell",
+            ties=ties,
+        )
+        np.testing.assert_allclose(actual, expected, equal_nan=True)
+
+
+def test_private_right_censored_risk_counts_match_brute_force_for_random_small_inputs():
+    rng = np.random.default_rng(0)
+
+    for n_samples in range(2, 10):
+        for _ in range(50):
+            event_times = rng.integers(1, 5, size=n_samples).astype(float)
+            event_indicators = rng.random(n_samples) < 0.65
+            risks = rng.integers(-2, 3, size=n_samples).astype(float)
+
+            actual = _right_censored_risk_counts(event_indicators, event_times, risks)
+            expected = _brute_harrell_counts(event_indicators, event_times, risks)
+
+            _assert_counts_close(actual, expected)
+
+
+def test_margin_concordance_sorts_pairs_by_best_guess_times():
+    event_indicators = np.array([True, False, True])
+    event_times = np.array([1.0, 2.0, 3.0])
+    bg_event_times = np.array([1.0, 4.0, 3.0])
+    partial_weights = np.array([1.0, 0.5, 1.0])
+    risks = np.array([3.0, 1.0, 2.0])
+
+    counts = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+    )
+    c_index, concordant, _ = _finalize_counts(counts, "Risk")
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 2.5)
+    assert np.isclose(counts.discordant, 0.0)
+    assert np.isclose(counts.risk_tie_pairs, 0.0)
+    assert np.isclose(counts.time_tie_pairs, 0.0)
+
+
+def test_margin_counts_match_brute_force_when_known_pairs_override_best_guess_order():
+    event_indicators = np.array([True, False, False, True])
+    event_times = np.array([2.0, 2.0, 4.0, 5.0])
+    bg_event_times = np.array([2.0, 2.0, 1.0, 5.0])
+    partial_weights = np.array([1.0, 0.25, 0.5, 1.0])
+    risks = np.array([3.0, 2.0, 1.0, 2.0])
+
+    actual = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+    )
+    expected = _brute_margin_counts(
+        event_indicators,
+        event_times,
+        risks,
+        bg_event_times,
+        partial_weights,
+    )
+
+    _assert_counts_close(actual, expected)
+    assert np.isclose(actual.concordant, 3.0)
+    assert np.isclose(actual.discordant, 0.625)
+    assert np.isclose(actual.time_tie_pairs, 0.0)
+
+
+def test_margin_known_pairs_full_weight_when_best_guess_times_tie():
+    event_indicators = np.array([True, False])
+    event_times = np.array([1.0, 1.0])
+    bg_event_times = np.array([1.0, 1.0])
+    partial_weights = np.array([1.0, 0.25])
+    risks = np.array([2.0, 1.0])
+
+    actual = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+    )
+
+    assert np.isclose(actual.concordant, 1.0)
+    assert np.isclose(actual.discordant, 0.0)
+    assert np.isclose(actual.risk_tie_pairs, 0.0)
+    assert np.isclose(actual.time_tie_pairs, 0.0)
+
+
+def test_margin_concordance_preserves_known_pairs_when_best_guess_times_tie():
+    event_indicators = np.array([True, False])
+    event_times = np.array([1.0, 1.0])
+    bg_event_times = np.array([1.0, 1.0])
+    partial_weights = np.array([1.0, 0.25])
+    risks = np.array([2.0, 1.0])
+
+    counts = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+    )
+    c_index, concordant, _ = _finalize_counts(counts, "Risk")
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 1.0)
+    assert np.isclose(counts.discordant, 0.0)
+    assert np.isclose(counts.risk_tie_pairs, 0.0)
+    assert np.isclose(counts.time_tie_pairs, 0.0)
 
 
 def test_get_comparable_ic_returns_directed_precedence_relation():

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -1,6 +1,50 @@
 import numpy as np
 
-from SurvivalEVAL.Evaluations.Concordance import _get_comparable_ic
+from SurvivalEVAL import PointEvaluator
+from SurvivalEVAL.Evaluations.Concordance import _get_comparable_ic, concordance
+
+
+def test_concordance_default_gives_half_credit_to_tied_risk_predictions():
+    predicted_times = np.array([1.0, 1.0, 3.0])
+    event_times = np.array([1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1])
+
+    c_default, concordant_default, total_default = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+    )
+    c_no_ties, concordant_no_ties, total_no_ties = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+        ties="None",
+    )
+
+    assert np.isclose(c_default, 5.0 / 6.0)
+    assert np.isclose(concordant_default, 2.5)
+    assert np.isclose(total_default, 3.0)
+    assert np.isclose(c_no_ties, 1.0)
+    assert np.isclose(concordant_no_ties, 2.0)
+    assert np.isclose(total_no_ties, 2.0)
+
+
+def test_point_evaluator_concordance_default_uses_standard_harrell_tie_handling():
+    evaluator = PointEvaluator(
+        pred_times=np.array([1.0, 1.0, 3.0]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 1, 1]),
+    )
+
+    c_default, concordant_default, total_default = evaluator.concordance()
+    c_risk, concordant_risk, total_risk = evaluator.concordance(ties="Risk")
+
+    assert np.isclose(c_default, c_risk)
+    assert np.isclose(concordant_default, concordant_risk)
+    assert np.isclose(total_default, total_risk)
+    assert np.isclose(c_default, 5.0 / 6.0)
 
 
 def test_get_comparable_ic_returns_directed_precedence_relation():

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -22,7 +22,11 @@ def _add_directed_pair(counts, risks, anchor, candidate, weight=1.0, tied_tol=1e
         counts.discordant += weight
 
 
-def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=None):
+def _before_tau(time, tau):
+    return tau is None or time < tau
+
+
+def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=None, tau=None):
     if sample_weights is None:
         sample_weights = np.ones(event_times.shape[0], dtype=float)
     counts = ConcordanceCounts()
@@ -33,11 +37,14 @@ def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=N
                 event_indicators[i]
                 and event_indicators[j]
                 and event_times[i] == event_times[j]
+                and _before_tau(event_times[i], tau)
             ):
                 counts.time_tie_pairs += sample_weights[i] * sample_weights[j]
 
     for i in range(event_times.shape[0]):
         if not event_indicators[i]:
+            continue
+        if not _before_tau(event_times[i], tau):
             continue
         for j in range(event_times.shape[0]):
             if i == j:
@@ -59,13 +66,14 @@ def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=N
 
 
 def _brute_margin_counts(
-    event_indicators, event_times, risks, bg_event_times, partial_weights
+    event_indicators, event_times, risks, bg_event_times, partial_weights, tau=None
 ):
     counts = _brute_harrell_counts(
         np.ones_like(event_indicators, dtype=bool),
         bg_event_times,
         risks,
         sample_weights=partial_weights,
+        tau=tau,
     )
 
     for i in range(event_times.shape[0]):
@@ -82,14 +90,21 @@ def _brute_margin_counts(
                 continue
 
             baseline_weight = partial_weights[i] * partial_weights[j]
-            if bg_event_times[i] < bg_event_times[j]:
+            if bg_event_times[i] < bg_event_times[j] and _before_tau(
+                bg_event_times[i], tau
+            ):
                 _add_directed_pair(counts, risks, i, j, weight=-baseline_weight)
-            elif bg_event_times[i] > bg_event_times[j]:
+            elif bg_event_times[i] > bg_event_times[j] and _before_tau(
+                bg_event_times[j], tau
+            ):
                 _add_directed_pair(counts, risks, j, i, weight=-baseline_weight)
-            else:
+            elif bg_event_times[i] == bg_event_times[j] and _before_tau(
+                bg_event_times[i], tau
+            ):
                 counts.time_tie_pairs -= baseline_weight
 
-            _add_directed_pair(counts, risks, i, j, weight=1.0)
+            if _before_tau(event_times[i], tau):
+                _add_directed_pair(counts, risks, i, j, weight=1.0)
 
     return counts
 
@@ -99,33 +114,6 @@ def _assert_counts_close(actual, expected):
     assert np.isclose(actual.discordant, expected.discordant)
     assert np.isclose(actual.risk_tie_pairs, expected.risk_tie_pairs)
     assert np.isclose(actual.time_tie_pairs, expected.time_tie_pairs)
-
-
-def test_concordance_default_gives_half_credit_to_tied_risk_predictions():
-    predicted_times = np.array([1.0, 1.0, 3.0])
-    event_times = np.array([1.0, 2.0, 3.0])
-    event_indicators = np.array([1, 1, 1])
-
-    c_default, concordant_default, total_default = concordance(
-        predicted_times,
-        event_times,
-        event_indicators,
-        method="Harrell",
-    )
-    c_no_ties, concordant_no_ties, total_no_ties = concordance(
-        predicted_times,
-        event_times,
-        event_indicators,
-        method="Harrell",
-        ties="None",
-    )
-
-    assert np.isclose(c_default, 5.0 / 6.0)
-    assert np.isclose(concordant_default, 2.5)
-    assert np.isclose(total_default, 3.0)
-    assert np.isclose(c_no_ties, 1.0)
-    assert np.isclose(concordant_no_ties, 2.0)
-    assert np.isclose(total_no_ties, 2.0)
 
 
 def test_point_evaluator_concordance_default_uses_standard_harrell_tie_handling():
@@ -144,7 +132,33 @@ def test_point_evaluator_concordance_default_uses_standard_harrell_tie_handling(
     assert np.isclose(c_default, 5.0 / 6.0)
 
 
-def test_concordance_tie_modes_separate_risk_time_and_censoring_ties():
+def test_point_evaluator_concordance_forwards_tau():
+    evaluator = PointEvaluator(
+        pred_times=np.array([1.0, 2.0, 3.0, 4.0]),
+        event_times=np.array([1.0, 2.0, 3.0, 4.0]),
+        event_indicators=np.array([1, 1, 1, 1]),
+    )
+
+    c_index, concordant, total = evaluator.concordance(tau=2.0)
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 3.0)
+    assert np.isclose(total, 3.0)
+
+
+@pytest.mark.parametrize("method", ["Margin", "Uno", "IPCW"])
+def test_point_evaluator_concordance_train_required_methods_need_training_data(method):
+    evaluator = PointEvaluator(
+        pred_times=np.array([1.0, 2.0, 3.0]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 1]),
+    )
+
+    with pytest.raises(TypeError, match="Train set information is missing"):
+        evaluator.concordance(method=method)
+
+
+def test_concordance_tie_modes_and_default_risk_handling():
     # This example has 8 concordant pairs, 3 discordant pairs, 5 comparable
     # risk ties, and 2 event-event time ties. It also includes event-censored
     # same-time pairs and censored-censored same-time pairs, which must not be
@@ -153,6 +167,11 @@ def test_concordance_tie_modes_separate_risk_time_and_censoring_ties():
     event_times = np.array([1.0, 1.0, 2.0, 1.0, 3.0, 2.0, 2.0, 3.0])
     event_indicators = np.array([1, 1, 1, 0, 1, 0, 0, 1])
 
+    c_default, concordant_default, total_default = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+    )
     c_none, concordant_none, total_none = concordance(
         predicted_times,
         event_times,
@@ -177,6 +196,10 @@ def test_concordance_tie_modes_separate_risk_time_and_censoring_ties():
         event_indicators,
         ties="All",
     )
+
+    assert np.isclose(c_default, c_risk)
+    assert np.isclose(concordant_default, concordant_risk)
+    assert np.isclose(total_default, total_risk)
 
     assert np.isclose(c_none, 8.0 / 11.0)
     assert np.isclose(concordant_none, 8.0)
@@ -224,6 +247,66 @@ def test_harrell_concordance_matches_brute_force_edge_cases(ties):
         np.testing.assert_allclose(actual, expected, equal_nan=True)
 
 
+def test_harrell_tau_none_preserves_existing_result():
+    predicted_times = np.array([1.0, 1.0, 3.0, 2.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_indicators = np.array([1, 0, 1, 1])
+
+    expected = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+        ties="All",
+    )
+    actual = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+        ties="All",
+        tau=None,
+    )
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_harrell_tau_excludes_anchors_at_boundary():
+    predicted_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1, 1])
+
+    c_index, concordant, total = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+        tau=2.0,
+    )
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 3.0)
+    assert np.isclose(total, 3.0)
+
+
+def test_harrell_tau_allows_candidates_after_tau():
+    predicted_times = np.array([1.0, 3.0, 4.0])
+    event_times = np.array([1.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1])
+
+    c_index, concordant, total = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        method="Harrell",
+        tau=2.0,
+    )
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 2.0)
+    assert np.isclose(total, 2.0)
+
+
 def test_private_right_censored_risk_counts_match_brute_force_for_random_small_inputs():
     rng = np.random.default_rng(0)
 
@@ -237,6 +320,124 @@ def test_private_right_censored_risk_counts_match_brute_force_for_random_small_i
             expected = _brute_harrell_counts(event_indicators, event_times, risks)
 
             _assert_counts_close(actual, expected)
+
+
+def test_private_right_censored_risk_counts_match_brute_force_with_tau():
+    rng = np.random.default_rng(1)
+
+    for n_samples in range(2, 10):
+        for _ in range(50):
+            event_times = rng.integers(1, 6, size=n_samples).astype(float)
+            event_indicators = rng.random(n_samples) < 0.65
+            risks = rng.integers(-2, 3, size=n_samples).astype(float)
+            tau = float(rng.integers(1, 6))
+
+            actual = _right_censored_risk_counts(
+                event_indicators, event_times, risks, tau=tau
+            )
+            expected = _brute_harrell_counts(
+                event_indicators, event_times, risks, tau=tau
+            )
+
+            _assert_counts_close(actual, expected)
+
+
+def test_uno_concordance_uses_censoring_distribution_ipcw():
+    predicted_times = np.array([1.0, 4.0, 2.0, 3.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1, 1])
+    train_event_times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    train_event_indicators = np.array([1, 0, 1, 0, 1])
+
+    actual = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="Uno",
+    )
+    alias = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="IPCW",
+    )
+
+    expected = (43.0 / 75.0, 43.0 / 9.0, 25.0 / 3.0)
+    np.testing.assert_allclose(actual, expected)
+    np.testing.assert_allclose(alias, expected)
+
+
+def test_uno_tau_excludes_anchors_at_and_after_tau():
+    predicted_times = np.array([1.0, 4.0, 2.0, 3.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1, 1])
+    train_event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    train_event_indicators = np.array([1, 1, 1, 1])
+
+    without_tau = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="Uno",
+    )
+    with_tau = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="Uno",
+        tau=3.0,
+    )
+    alias = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="IPCW",
+        tau=3.0,
+    )
+
+    np.testing.assert_allclose(without_tau, (4.0 / 6.0, 4.0, 6.0))
+    np.testing.assert_allclose(with_tau, (3.0 / 5.0, 3.0, 5.0))
+    np.testing.assert_allclose(alias, with_tau)
+
+
+def test_uno_tau_ignores_zero_censoring_survival_for_excluded_anchors():
+    predicted_times = np.array([1.0, 3.0])
+    event_times = np.array([1.0, 3.0])
+    event_indicators = np.array([1, 1])
+    train_event_times = np.array([1.0, 2.0])
+    train_event_indicators = np.array([0, 0])
+
+    with pytest.raises(ValueError):
+        concordance(
+            predicted_times,
+            event_times,
+            event_indicators,
+            train_event_times=train_event_times,
+            train_event_indicators=train_event_indicators,
+            method="Uno",
+        )
+
+    actual = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="Uno",
+        tau=2.0,
+    )
+
+    np.testing.assert_allclose(actual, (1.0, 4.0, 4.0))
 
 
 def test_margin_concordance_sorts_pairs_by_best_guess_times():
@@ -305,33 +506,87 @@ def test_margin_known_pairs_full_weight_when_best_guess_times_tie():
         partial_weights=partial_weights,
     )
 
+    c_index, concordant, _ = _finalize_counts(actual, "Risk")
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 1.0)
     assert np.isclose(actual.concordant, 1.0)
     assert np.isclose(actual.discordant, 0.0)
     assert np.isclose(actual.risk_tie_pairs, 0.0)
     assert np.isclose(actual.time_tie_pairs, 0.0)
 
 
-def test_margin_concordance_preserves_known_pairs_when_best_guess_times_tie():
-    event_indicators = np.array([True, False])
-    event_times = np.array([1.0, 1.0])
-    bg_event_times = np.array([1.0, 1.0])
-    partial_weights = np.array([1.0, 0.25])
-    risks = np.array([2.0, 1.0])
+def test_margin_tau_filters_baseline_by_best_guess_anchor_time():
+    event_indicators = np.array([False, False, False])
+    event_times = np.array([10.0, 10.0, 10.0])
+    bg_event_times = np.array([1.0, 2.0, 3.0])
+    partial_weights = np.ones(3)
+    risks = np.array([3.0, 2.0, 1.0])
 
-    counts = _margin_counts(
+    actual = _margin_counts(
         event_indicators,
         event_times,
         estimate=risks,
         bg_event_time=bg_event_times,
         partial_weights=partial_weights,
+        tau=2.0,
     )
-    c_index, concordant, _ = _finalize_counts(counts, "Risk")
+    expected = _brute_margin_counts(
+        event_indicators,
+        event_times,
+        risks,
+        bg_event_times,
+        partial_weights,
+        tau=2.0,
+    )
 
-    assert np.isclose(c_index, 1.0)
-    assert np.isclose(concordant, 1.0)
-    assert np.isclose(counts.discordant, 0.0)
-    assert np.isclose(counts.risk_tie_pairs, 0.0)
-    assert np.isclose(counts.time_tie_pairs, 0.0)
+    _assert_counts_close(actual, expected)
+    assert np.isclose(actual.concordant, 2.0)
+    assert np.isclose(actual.discordant, 0.0)
+
+
+def test_margin_tau_adds_observed_replacement_by_observed_anchor_time():
+    event_indicators = np.array([True, False])
+    event_times = np.array([1.0, 1.0])
+    bg_event_times = np.array([3.0, 4.0])
+    partial_weights = np.array([1.0, 0.25])
+    risks = np.array([2.0, 1.0])
+
+    actual = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+        tau=2.0,
+    )
+
+    assert np.isclose(actual.concordant, 1.0)
+    assert np.isclose(actual.discordant, 0.0)
+    assert np.isclose(actual.risk_tie_pairs, 0.0)
+    assert np.isclose(actual.time_tie_pairs, 0.0)
+
+
+def test_margin_tau_removes_baseline_without_observed_replacement_after_tau():
+    event_indicators = np.array([True, False])
+    event_times = np.array([2.0, 2.0])
+    bg_event_times = np.array([1.0, 4.0])
+    partial_weights = np.array([1.0, 0.25])
+    risks = np.array([2.0, 1.0])
+
+    actual = _margin_counts(
+        event_indicators,
+        event_times,
+        estimate=risks,
+        bg_event_time=bg_event_times,
+        partial_weights=partial_weights,
+        tau=2.0,
+    )
+
+    assert np.isclose(actual.concordant, 0.0)
+    assert np.isclose(actual.discordant, 0.0)
+    assert np.isclose(actual.risk_tie_pairs, 0.0)
+    assert np.isclose(actual.time_tie_pairs, 0.0)
 
 
 def test_get_comparable_ic_returns_directed_precedence_relation():

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -411,11 +411,11 @@ def test_uno_tau_excludes_anchors_at_and_after_tau():
 
 
 def test_uno_tau_ignores_zero_censoring_survival_for_excluded_anchors():
-    predicted_times = np.array([1.0, 3.0])
-    event_times = np.array([1.0, 3.0])
-    event_indicators = np.array([1, 1])
-    train_event_times = np.array([1.0, 2.0])
-    train_event_indicators = np.array([0, 0])
+    predicted_times = np.array([1.0, 3.0, 4.0])
+    event_times = np.array([1.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1])
+    train_event_times = np.array([1.0, 3.0])
+    train_event_indicators = np.array([1, 0])
 
     with pytest.raises(ValueError):
         concordance(
@@ -437,7 +437,27 @@ def test_uno_tau_ignores_zero_censoring_survival_for_excluded_anchors():
         tau=2.0,
     )
 
-    np.testing.assert_allclose(actual, (1.0, 4.0, 4.0))
+    np.testing.assert_allclose(actual, (1.0, 2.0, 2.0))
+
+
+def test_uno_ignores_zero_censoring_survival_for_non_contributing_final_anchor():
+    predicted_times = np.array([1.0, 2.0, 3.0])
+    event_times = np.array([1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1])
+    train_event_times = np.array([1.0, 2.0, 3.0])
+    train_event_indicators = np.array([1, 1, 0])
+
+    actual = concordance(
+        predicted_times,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="Uno",
+        tau=4.0,
+    )
+
+    np.testing.assert_allclose(actual, (1.0, 3.0, 3.0))
 
 
 def test_margin_concordance_sorts_pairs_by_best_guess_times():

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -26,7 +26,9 @@ def _before_tau(time, tau):
     return tau is None or time < tau
 
 
-def _brute_harrell_counts(event_indicators, event_times, risks, sample_weights=None, tau=None):
+def _brute_harrell_counts(
+    event_indicators, event_times, risks, sample_weights=None, tau=None
+):
     if sample_weights is None:
         sample_weights = np.ones(event_times.shape[0], dtype=float)
     counts = ConcordanceCounts()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -210,6 +210,49 @@ def test_concordance_variants(evaluator_data):
     assert concordant_m <= total_m
 
 
+def test_survival_evaluator_concordance_forwards_tau():
+    time_grid = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    pred_survs = np.array(
+        [
+            [1.0, 0.5, 0.0, 0.0, 0.0],
+            [1.0, 0.75, 0.5, 0.0, 0.0],
+            [1.0, 0.8, 0.7, 0.5, 0.0],
+            [1.0, 0.9, 0.8, 0.7, 0.5],
+        ]
+    )
+    evaluator = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0, 3.0, 4.0]),
+        event_indicators=np.array([1, 1, 1, 1]),
+    )
+
+    c_index, concordant, total = evaluator.concordance(tau=2.0)
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, 3.0)
+    assert np.isclose(total, 3.0)
+
+
+@pytest.mark.parametrize("method", ["Margin", "Uno", "IPCW"])
+def test_survival_evaluator_concordance_train_required_methods_need_training_data(method):
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.array(
+            [
+                [1.0, 0.5, 0.2],
+                [1.0, 0.7, 0.4],
+                [1.0, 0.8, 0.6],
+            ]
+        ),
+        time_coordinates=np.array([0.0, 1.0, 2.0]),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 1]),
+    )
+
+    with pytest.raises(TypeError, match="Train set information is missing"):
+        evaluator.concordance(method=method)
+
+
 def test_auc_alias(evaluator_data):
     evaluator = evaluator_data["evaluator"]
     auc = evaluator.auc(target_time=9.0)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -235,7 +235,9 @@ def test_survival_evaluator_concordance_forwards_tau():
 
 
 @pytest.mark.parametrize("method", ["Margin", "Uno", "IPCW"])
-def test_survival_evaluator_concordance_train_required_methods_need_training_data(method):
+def test_survival_evaluator_concordance_train_required_methods_need_training_data(
+    method,
+):
     evaluator = SurvivalEvaluator(
         pred_survs=np.array(
             [

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -342,9 +342,9 @@ def test_case_4_comparison_with_paper():
     train_widths = np.random.uniform(1.5, 5, n_samples)
     train_left_limits = np.maximum(0, train_true_times - train_widths / 2)
     train_right_limits = train_true_times + train_widths / 2
-    train_right_limits[
-        np.random.choice([True, False], n_samples, p=[0.25, 0.75])
-    ] = np.inf
+    train_right_limits[np.random.choice([True, False], n_samples, p=[0.25, 0.75])] = (
+        np.inf
+    )
 
     print(f"Samples: {n_samples}, Time points: {n_time_points}")
     print(f"Max observation time: {max_time}")


### PR DESCRIPTION
# Description

Adds and documents expanded right-censored concordance behavior, including tie handling refactors, method aliases, IPCW/Uno support, and optional strict tau truncation for Harrell/Naive, Uno/IPCW, and Margin concordance.

## Updates

1. Refactored right-censored concordance pair counting into count helpers with explicit tie-mode finalization.
2. Added `tau` truncation to the right-censored `concordance()` API and evaluator wrappers.
3. Added `Naive` as a Harrell alias and `IPCW` as a Uno alias.
4. Added Uno/IPCW censoring-survival weighting and training-data validation through evaluator wrappers.
5. Limited Uno/IPCW zero censoring-survival validation to observed-event anchors that can actually contribute raw concordance counts.
6. Updated README and docstrings for the expanded concordance API.
7. Added public tests for tie modes, evaluator forwarding, Uno/IPCW behavior, Margin behavior, tau boundary semantics, and non-contributing final anchors.

## Fixes

1. Fixes concordance time-tie accounting so event-event time ties, risk ties, and censoring same-time cases are handled separately.
2. Fixes weighted total-pair typing/documentation for IPCW-style concordance totals.
3. Fixes Uno/IPCW validation so a final observed event with zero censoring survival but no comparable candidates does not fail otherwise valid pair counting.

## Mandatory Checklist

- [x] All new or modified features have corresponding test cases.

- [x] I have run all the tests, using `pytest`, and this is the log I get:

```bash
conda run -n SurvEVAL pytest tests/test_concordance.py tests/test_evaluator.py tests/test_quantile_evaluator.py tests/test_pycox.py

============================= test session starts ==============================
platform linux -- Python 3.11.10, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/shiang/Documents/GithubRepository/SurvivalEVAL
configfile: pyproject.toml
plugins: anyio-4.6.2
collected 68 items

tests/test_concordance.py ...........................                    [ 39%]
tests/test_evaluator.py ..............................                   [ 83%]
tests/test_quantile_evaluator.py ........                                [ 95%]
tests/test_pycox.py ...                                                  [100%]

======================= 68 passed, 13 warnings in 4.40s ========================
```

Additional checks:

```bash
git diff --check
# passed

awk 'length($0) > 120 { print FILENAME ":" FNR ":" length($0) ":" $0 }' README.md SurvivalEVAL/Evaluations/Concordance.py SurvivalEVAL/Evaluator.py tests/test_concordance.py tests/test_evaluator.py
# no output

conda run -n SurvEVAL isort --check-only SurvivalEVAL/Evaluations/Concordance.py SurvivalEVAL/Evaluator.py tests/test_concordance.py tests/test_evaluator.py
# passed
```

- [x] All new functions, classes, and modules contain clear docstrings and inline comments.

- [x] All jupyter notebooks are runnable with expected results. No notebooks were changed.

- [ ] I have reformatted and ran `isort .` and `black .` (in this same order) on the codebase.

Formatter notes:

```bash
conda run -n SurvEVAL isort --check-only .
# failed only in tests/private files, which this PR does not touch and pytest ignores

conda run -n SurvEVAL black --check .
# did not complete in this environment and was interrupted

conda run -n SurvEVAL black --check SurvivalEVAL/Evaluations/Concordance.py SurvivalEVAL/Evaluator.py tests/test_concordance.py tests/test_evaluator.py
# also did not complete in this environment and was interrupted
```

- [x] I have updated the README and added or edited any new scripts to the integration tests.

- [x] I have ensured sufficient coverage on the newly implemented features.

- [x] I have made sure that both the `requirements.txt` and `pyproject.toml` files are updated according to the newly introduced dependencies. No new dependencies were introduced.

- [x] Paste the remaining code TODOs using the command `grep -rI --color=auto --exclude-dir={.git,__pycache__,env_folder,.venv,venv,.cache,output,.github,} 'TODO' .` here, and explain them if necessary:

```bash
./tests/private/test_fast_PO.py:            total_expect_time = total_km_model._compute_best_guess(0) # TODO: check why best_guess and _best_guess_revise give different results
./tests/private/test_fast_PO.py:            # TODO: no outliers
./tests/private/test_po.py:            total_expect_time = total_km_model._compute_best_guess(0) # TODO: check why best_guess and _best_guess_revise give different results
./tests/private/test_po.py:            # TODO: no outliers
./SurvivalEVAL/Evaluations/MeanError.py:                # Numpy will throw a warning if afterward_event_times are all false. TODO: consider change the code.
./SurvivalEVAL/Evaluations/MeanError.py:    # TODO: We need to move the logarithm transformation later after we calculate a best-guess.
./setup.py:TODO:
./AGENTS.md:5. **TODO Comments**: Mark issues in existing code with "TODO:" prefix
./AGENTS.md:PRs should follow `.github/pull_request_template.md`: include a summary, feature use case or bug reproduction details, linked issues, pytest output, and remaining TODOs. Update README, notebooks, tests, and dependency files when behavior or requirements change.
./build/lib/SurvivalEVAL/Evaluations/MeanError.py:                # Numpy will throw a warning if afterward_event_times are all false. TODO: consider change the code.
./build/lib/SurvivalEVAL/Evaluations/MeanError.py:    # TODO: We need to move the logarithm transformation later after we calculate a best-guess.
```

These TODOs are pre-existing and unrelated to this concordance update.