### PR TITLE
Add time-dependent concordance metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 2026-06-17: Version 0.8.0
+
+1. Add Antolini-style time-dependent concordance through the lower-level
+   `concordance_time_dependent` function and `SurvivalEvaluator.concordance_time_dependent`.
+2. Add survival-probability and hazard-rate risk modes for time-dependent concordance, including the
+   Gandy-Matcham hazard-rate IPCW usage for crossing-hazards models.
+3. Add IPCW weighting, strict before-`tau` anchor filtering, training-data validation, and tie handling for
+   time-dependent concordance.
+4. Add hazard prediction support and consistent target-time validation for evaluator probability and hazard lookups.
+5. Add regression tests for time-dependent pair counting, IPCW weighting, tie policies, `tau` filtering,
+   input validation, and evaluator end-to-end behavior.
+6. Reconstruct the README metric reference with paper-linked tables covering the documented right-censored,
+   interval-censored, helper, and estimator APIs.
+
 ## 2026-06-16: Version 0.7.0
 
 1. Add Uno's right-censored concordance index through the `"Uno"` method, with `"IPCW"` kept as an alias.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ SurvivalEVAL groups metrics by prediction target:
 
 <p align="center">
   <a href="https://github.com/shi-ang/SurvivalEVAL/blob/main/all_metrics.png">
-    <img alt="Visualization of the evaluation metrics" src="https://github.com/shi-ang/SurvivalEVAL/blob/main/all_metrics.png"></a>
+    <img alt="Visualization of the evaluation metrics" src="https://raw.githubusercontent.com/shi-ang/SurvivalEVAL/main/all_metrics.png"></a>
 </p>
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ The public tests and examples show typical model integrations. See
 quantile prediction, point prediction, interpolation choices, and monotonicity
 handling.
 
+## Metric Guide
+
+SurvivalEVAL groups metrics by prediction target:
+
+- Point prediction metrics compare predicted event times with observed
+  event/censoring times.
+- Single-time probability metrics evaluate survival or event probability at one
+  target time.
+- Survival distribution metrics evaluate the full predicted survival curve.
+- Interval-censored metrics evaluate survival curves against observed event
+  intervals.
+
+<p align="center">
+  <a href="https://github.com/shi-ang/SurvivalEVAL/blob/main/all_metrics.png">
+    <img alt="Visualization of the evaluation metrics" src="https://github.com/shi-ang/SurvivalEVAL/blob/main/all_metrics.png"></a>
+</p>
+
 ## Installation
 
 Install from PyPI:
@@ -111,6 +128,8 @@ evl = LifelinesEvaluator(
 )
 
 c_index, concordant, total = evl.concordance(method="Harrell")
+td_c_index, td_concordant, td_total = evl.concordance_time_dependent(method="Antolini")
+
 mae = evl.mae(method="Pseudo_obs")
 ibs = evl.integrated_brier_score(num_points=53)
 d_cal_p, d_cal_hist = evl.d_calibration()
@@ -175,54 +194,81 @@ Right-censored survival-curve evaluators include `SurvivalEvaluator`,
 `LifelinesEvaluator`, `PycoxEvaluator`, `ScikitSurvivalEvaluator`, and
 `QuantileRegEvaluator`.
 
-### Point Prediction Metrics
+### Point Prediction Discrimination
 
 These metrics compare predicted survival times with observed event/censoring
-times. Predicted times are derived from survival curves using the configured
-`predict_time_method`: `"Median"`, `"Mean"`, or `"RMST"`.
+times. For survival-curve evaluators, predicted times are derived using the
+configured `predict_time_method`: `"Median"`, `"Mean"`, or `"RMST"`.
 
-- Concordance index: `evl.concordance(method="Harrell")` or
-  `evl.concordance(method="Naive")`
-- IPCW/Uno concordance: `evl.concordance(method="Uno")` or
-  `evl.concordance(method="IPCW")`
-- Margin concordance: `evl.concordance(method="Margin")`
-- Optional concordance truncation: `evl.concordance(..., tau=...)`
-- Mean absolute error: `evl.mae(method=...)`
-- Mean squared error: `evl.mse(method=...)`
-- Root mean squared error: `evl.rmse(method=...)`
-- Log-rank and weighted log-rank tests: `evl.log_rank(...)`
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Harrell's C-index | Uses observed-event comparable pairs and checks whether earlier observed events receive higher risk. | `evl.concordance(method="Harrell")` | [Harrell et al.](https://onlinelibrary.wiley.com/doi/10.1002/(SICI)1097-0258(19960229)15:4%3C361::AID-SIM168%3E3.0.CO;2-4) |
+| Uno/IPCW C-index | Adds inverse-probability-of-censoring weights to comparable pairs. | `evl.concordance(method="Uno")` or `evl.concordance(method="IPCW")` | [Uno et al.](https://onlinelibrary.wiley.com/doi/10.1002/sim.4154) |
+| Truncated C-index | Counts only pairs whose earlier or anchor time is strictly before `tau`. | `evl.concordance(method=..., tau=...)` | [Uno et al.](https://onlinelibrary.wiley.com/doi/10.1002/sim.4154) |
+| Margin C-index | Replaces censored times with best-guess survival times before calculating C-index. | `evl.concordance(method="Margin")` | [Kumar et al.](https://www.nature.com/articles/s41598-022-08601-6) |
 
-`"Uno"`, `"IPCW"`, and `"Margin"` concordance require training event times
-and indicators. For right-censored concordance, `tau` keeps pairs whose
-effective earlier or anchor time is strictly before `tau`; when omitted, no
-truncation is applied.
+`"Uno"`, `"IPCW"`, and `"Margin"` require training event times and indicators.
+When `tau` is omitted, no concordance truncation is applied.
 
-Error methods include `"Uncensored"`, `"Hinge"`, `"Margin"`, `"IPCW-T"`,
-`"IPCW-D"`, and `"Pseudo_obs"`.
+### Point Prediction Errors And Reliability
+
+MAE, MSE, and RMSE share the same censoring-handling methods. Use
+`evl.mae(method=...)`, `evl.mse(method=...)`, or `evl.rmse(method=...)`.
+
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Uncensored error | Calculates error on observed-event samples only. | `evl.mae(method="Uncensored")` | N/A |
+| Hinge error | Penalizes censored samples only when the prediction is earlier than the censoring time. | `evl.mae(method="Hinge")` | [Shivaswamy et al.](https://ieeexplore.ieee.org/document/4470306/) |
+| Margin error | Replaces censored times with KM-based best guesses. | `evl.mae(method="Margin")` | [Haider et al.](https://jmlr.org/papers/v21/18-772.html) |
+| IPCW-T error | Uses surrogate event times from later observed events with censoring weights. | `evl.mae(method="IPCW-T")` | [Qi et al.](https://proceedings.mlr.press/v202/qi23b/qi23b.pdf) |
+| IPCW-D error | Uses IPCW weights directly on observed-event errors. | `evl.mae(method="IPCW-D")` | [Qi et al.](https://proceedings.mlr.press/v202/qi23b/qi23b.pdf) |
+| Pseudo-observation error | De-censors censored observations with pseudo-observed event times. | `evl.mae(method="Pseudo_obs")` | [Qi et al.](https://proceedings.mlr.press/v202/qi23b/qi23b.pdf) |
+| MSE | Uses the same methods as MAE with squared errors. | `evl.mse(method=...)` | Same as selected method |
+| RMSE | Square root of MSE using the same methods as MAE. | `evl.rmse(method=...)` | Same as selected method |
+| Log-rank test | Compares observed event times with predicted event times; weighted variants are available. | `evl.log_rank(weightings=...)` | [Mantel](https://pubmed.ncbi.nlm.nih.gov/5910392/) |
+
+`"Margin"`, `"IPCW-T"`, `"IPCW-D"`, and `"Pseudo_obs"` require training event
+times and indicators. Hinge uses training data only when `weighted=True`.
 
 ### Single-Time Probability Metrics
 
-These metrics evaluate survival probabilities at a specified target time:
+These metrics evaluate survival probabilities at a specified target time. Use
+`SingleTimeEvaluator` when the model only outputs one survival probability per
+patient at one target time.
 
-- AUROC/AUC: `evl.auc(target_time=...)` or `evl.auroc(target_time=...)`
-- Brier score: `evl.brier_score(target_time=..., IPCW_weighted=True)`
-- Hosmer-Lemeshow calibration: `evl.one_calibration(target_time=...)`
-- Integrated calibration index: `evl.integrated_calibration_index(...)`
-
-Use `SingleTimeEvaluator` when the model only outputs one survival probability
-per patient at one target time.
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| AUC/AUROC | Calculates ROC AUC after excluding samples censored before the target time. | `evl.auc(target_time=...)` or `evl.auroc(target_time=...)` | N/A |
+| Plain Brier score | Mean squared error between survival status and predicted survival probability without IPCW. | `evl.brier_score(target_time=..., IPCW_weighted=False)` | [Brier](https://doi.org/10.1175/1520-0493(1950)078%3C0001:VOEPIT%3E2.0.CO;2) |
+| IPCW Brier score | Brier score with inverse-probability-of-censoring weights. | `evl.brier_score(target_time=..., IPCW_weighted=True)` | [Graf et al.](https://pubmed.ncbi.nlm.nih.gov/10474158/) |
+| Uncensored HL calibration | Hosmer-Lemeshow calibration test on uncensored samples. | `evl.one_calibration(target_time=..., method="Uncensored")` | [Hosmer and Lemeshow](https://www.tandfonline.com/doi/abs/10.1080/03610928008827941) |
+| DN HL calibration | D'Agostino-Nam extension using Kaplan-Meier estimates for observed probabilities. | `evl.one_calibration(target_time=..., method="DN")` | [D'Agostino and Nam](https://www.sciencedirect.com/science/article/pii/S0169716103230017) |
+| Integrated calibration index | Smooth calibration-curve summary at a target time. | `evl.integrated_calibration_index(target_time=...)` | [Austin et al.](https://onlinelibrary.wiley.com/doi/abs/10.1002/sim.8570) |
 
 ### Survival Distribution Metrics
 
-These metrics evaluate the full predicted survival curve:
+These metrics evaluate the full predicted survival curve.
 
-- Integrated Brier score: `evl.integrated_brier_score(...)`
-- Survival-AUPRC: `evl.auprc()`
-- D-calibration: `evl.d_calibration()`
-- K-S D-calibration: `evl.ksd_calibration()`
-- KM calibration: `evl.km_calibration()`
-- Cox-Snell, modified Cox-Snell, Martingale, and Deviance residuals:
-  `evl.residuals(method=...)`
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Antolini's time-dependent C-index | Uses survival-curve risk scores at observed-event anchors. | `evl.concordance_time_dependent(method="Antolini", risks="Survival")` | [Antolini et al.](https://onlinelibrary.wiley.com/doi/10.1002/sim.2427) |
+| Gandy-Matcham time-dependent C-index | Uses hazard-rate risk scores for crossing hazards. | `evl.concordance_time_dependent(method="IPCW", risks="Hazard", tau=...)` | [Gandy and Matcham](https://onlinelibrary.wiley.com/doi/full/10.1111/sjos.70000) |
+| Plain integrated Brier score | Integrates unweighted Brier scores over a time grid. | `evl.integrated_brier_score(IPCW_weighted=False)` | [Graf et al.](https://pubmed.ncbi.nlm.nih.gov/10474158/) |
+| IPCW integrated Brier score | Integrates IPCW Brier scores over a time grid. | `evl.integrated_brier_score(IPCW_weighted=True)` | [Graf et al.](https://pubmed.ncbi.nlm.nih.gov/10474158/) |
+| Survival-AUPRC | Scores full survival distributions using area under the precision-recall curve. | `evl.auprc()` | [Avati et al.](https://proceedings.mlr.press/v115/avati20a.html) |
+| D-calibration | Tests whether predicted survival probabilities at event times follow a uniform distribution. | `evl.d_calibration()` | [Haider et al.](https://jmlr.org/papers/volume21/18-772/18-772.pdf) |
+| K-S D-calibration | Kolmogorov-Smirnov version of D-calibration. | `evl.ksd_calibration()` | [Qi et al.](https://ojs.aaai.org/index.php/AAAI-SS/article/view/27713) |
+| KM calibration | Compares the average predicted survival curve with the Kaplan-Meier curve. | `evl.km_calibration()` | [Chapfuwa et al.](https://ieeexplore.ieee.org/abstract/document/9244076/) |
+| Cox-Snell residuals | Uses cumulative hazard at the observed time to check goodness of fit. | `evl.residuals(method="CoxSnell")` | [Cox and Snell](https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/j.2517-6161.1968.tb00724.x) |
+| Modified Cox-Snell residuals | Adds an excess residual for censored subjects. | `evl.residuals(method="Modified CoxSnell-v1")` or `evl.residuals(method="Modified CoxSnell-v2")` | [Collett](https://www.taylorfrancis.com/books/mono/10.1201/b18041/modelling-survival-data-medical-research-david-collett) |
+| Martingale residuals | Calculates event indicator minus cumulative hazard. | `evl.residuals(method="Martingale")` | [Barlow and Prentice](https://academic.oup.com/biomet/article-abstract/75/1/65/352141) |
+| Deviance residuals | Transforms martingale residuals toward a normal residual scale. | `evl.residuals(method="Deviance")` | [Therneau et al.](https://academic.oup.com/biomet/article-abstract/77/1/147/271076) |
+
+For time-dependent concordance, `risks="Survival"` uses `-S(t | z)` as the risk
+score at each event anchor, while `risks="Hazard"` uses estimated hazard rates
+directly. `method="IPCW"` requires training event times and indicators. `tau`
+keeps event anchors whose observed time is strictly before `tau`; when omitted,
+no truncation is applied.
 
 ## Interval-Censored Metrics
 
@@ -230,70 +276,68 @@ These metrics evaluate the full predicted survival curve:
 endpoints. It supports exact events, left-censored observations, interval
 censoring, and right censoring within one interface.
 
-### Discrimination
+### Interval-Censored Discrimination
 
-- Comparable-pair interval concordance:
-  `evl.concordance(method="comparable")`
-- Probability-weighted interval concordance using a Turnbull estimator:
-  `evl.concordance(method="probability")`
-- Midpoint-imputed concordance:
-  `evl.concordance(method="midpoint")`
-- Survival-AUPRC for interval-censored outcomes: `evl.auprc()`
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Comparable-pair interval C-index | Counts interval-censored pairs that are comparable from observed endpoints. | `evl.concordance(method="comparable")` | [Qi et al.](https://ojs.aaai.org/index.php/AAAI-SS/article/view/27713) |
+| Probability-weighted interval C-index | Uses Turnbull-estimated pair weights for interval-censored comparable ordering. | `evl.concordance(method="probability")` | [Turnbull](https://www.jstor.org/stable/2285518) |
+| Midpoint-imputed C-index | Converts finite intervals to midpoint event times and right-censored intervals to censoring times. | `evl.concordance(method="midpoint")` | N/A |
+| Interval Survival-AUPRC | Extends Survival-AUPRC scoring to interval-censored outcomes. | `evl.auprc()` | [Avati et al.](https://proceedings.mlr.press/v115/avati20a.html) |
 
-### Error And Scoring Metrics
+### Interval-Censored Error And Scoring Metrics
 
-- Single-time interval Brier score:
-  `evl.brier_score(target_time=..., method=...)`
-- Multiple-time interval Brier score:
-  `evl.brier_score_multiple_points(target_times=..., method=...)`
-- Integrated Brier score:
-  `evl.integrated_brier_score(target_times=..., method=...)`
-- Continuous Ranked Probability Score:
-  `evl.crps(...)`
-- Point-prediction MAE/MSE/RMSE:
-  `evl.mae()`, `evl.mse()`, and `evl.rmse()`
-- Inclusion rate of point predictions in observed intervals:
-  `evl.inclusion_rate()`
-- Prediction-interval coverage:
-  `evl.coverage(cov_level=...)`
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Uncensored interval Brier score | Excludes samples whose event status is ambiguous at the target time. | `evl.brier_score(target_time=..., method="uncensored")` | [Brier](https://doi.org/10.1175/1520-0493(1950)078%3C0001:VOEPIT%3E2.0.CO;2) |
+| Tsouprou marginal Brier score | Uses marginal interval-censored survival estimates from the training intervals. | `evl.brier_score(target_time=..., method="Tsouprou-marginal")` | [Tsouprou](https://studenttheses.universiteitleiden.nl/access/item%3A3597164/view) |
+| Tsouprou conditional Brier score | Uses a conditional Weibull AFT model with `x` and `x_train` covariates. | `evl.brier_score(target_time=..., method="Tsouprou-conditional")` | [Tsouprou](https://studenttheses.universiteitleiden.nl/access/item%3A3597164/view) |
+| Multiple-time interval Brier score | Evaluates interval Brier scores on a supplied time grid. | `evl.brier_score_multiple_points(target_times=..., method=...)` | Same as selected Brier method |
+| Integrated interval Brier score | Integrates interval Brier scores over a time grid. | `evl.integrated_brier_score(target_times=..., method=...)` | Same as selected Brier method |
+| CRPS | Integrated unweighted interval Brier score, using survival CRPS terminology. | `evl.crps(...)` | [Avati et al.](https://proceedings.mlr.press/v115/avati20a.html) |
+| Interval MAE | One-sided absolute error that penalizes predictions outside the observed interval. | `evl.mae()` | [Shivaswamy et al.](https://ieeexplore.ieee.org/document/4470306/) |
+| Interval MSE | One-sided squared error that penalizes predictions outside the observed interval. | `evl.mse()` | [Shivaswamy et al.](https://ieeexplore.ieee.org/document/4470306/) |
+| Interval RMSE | Square root of interval MSE. | `evl.rmse()` | [Shivaswamy et al.](https://ieeexplore.ieee.org/document/4470306/) |
+| Inclusion rate | Fraction of point predictions that fall inside observed event intervals. | `evl.inclusion_rate()` | [Avati et al.](https://proceedings.mlr.press/v115/avati20a.html) |
+| Interval prediction coverage | Fractional coverage of observed intervals by predicted intervals. | `evl.coverage(cov_level=...)` | [Qi et al.](https://ojs.aaai.org/index.php/AAAI-SS/article/view/27713) |
 
-Interval Brier score methods include `"uncensored"`, `"Tsouprou-marginal"`,
-and `"Tsouprou-conditional"`. The conditional method additionally requires
-test and train covariates through `x` and `x_train`.
+The `"Tsouprou-conditional"` method requires test and train covariates through
+`x` and `x_train`.
 
-### Calibration
+### Interval-Censored Calibration
 
-- One-calibration with interval handling:
-  `evl.one_calibration(target_time=..., method="Turnbull")`
-- Midpoint one-calibration:
-  `evl.one_calibration(target_time=..., method="MidPoint")`
-- Interval D-calibration: `evl.d_calibration()`
-- Interval K-S D-calibration: `evl.ksd_calibration()`
+| Metric Name | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Turnbull one-calibration | One-time calibration using Turnbull interval estimates in prediction bins. | `evl.one_calibration(target_time=..., method="Turnbull")` | [Turnbull](https://www.jstor.org/stable/2285518) |
+| Midpoint one-calibration | One-time calibration after midpoint imputation of observed intervals. | `evl.one_calibration(target_time=..., method="MidPoint")` | N/A |
+| Interval D-calibration | D-calibration using probability intervals instead of exact event probabilities. | `evl.d_calibration()` | [Haider et al.](https://jmlr.org/papers/volume21/18-772/18-772.pdf) |
+| Interval K-S D-calibration | Kolmogorov-Smirnov D-calibration for interval-censored outcomes. | `evl.ksd_calibration()` | [Qi et al.](https://ojs.aaai.org/index.php/AAAI-SS/article/view/27713) |
 
 ## Other Evaluators And Helper APIs
 
-- `PointEvaluator` evaluates already-computed point survival-time predictions
-  with concordance, MAE, MSE, RMSE, and log-rank tests.
-- `SingleTimeEvaluator` evaluates already-computed survival probabilities at a
-  single target time with AUC, Brier score, one-calibration, and ICI.
-- `QuantileRegEvaluator` converts event-time quantile predictions into survival
-  curves and reuses the right-censored survival-curve metrics.
-- `SurvivalEVAL.Evaluations.OtherMetrics` includes lower-level research helpers
-  such as calibration slope and coefficient of variation.
+| API | Description | Typical Code |
+| --- | --- | --- |
+| `PointEvaluator` | Evaluates already-computed point survival-time predictions with concordance, MAE, MSE, RMSE, and log-rank tests. | `PointEvaluator(predicted_times, event_times, event_indicators, ...)` |
+| `SingleTimeEvaluator` | Evaluates already-computed survival probabilities at one target time with AUC, Brier score, one-calibration, and ICI. | `SingleTimeEvaluator(predicted_probs, event_times, event_indicators, ...)` |
+| `QuantileRegEvaluator` | Converts event-time quantile predictions into survival curves and reuses right-censored survival-curve metrics. | `QuantileRegEvaluator(predicted_quantiles, quantile_levels, ...)` |
+| Lower-level functions | Most evaluator methods are also available under `SurvivalEVAL.Evaluations` for advanced use cases. | `SurvivalEVAL.Evaluations.concordance(...)` |
 
-Most evaluator methods are also available as lower-level functions under
-`SurvivalEVAL.Evaluations` for advanced use cases.
+`SurvivalEVAL.Evaluations.OtherMetrics` includes research helpers such as
+calibration slope and coefficient of variation.
 
 ## Nonparametric Estimators
 
 The `SurvivalEVAL.NonparametricEstimator.SingleEvent` module includes:
 
-- Kaplan-Meier estimators: `KaplanMeier`, `KaplanMeierArea`
-- Nelson-Aalen estimator: `NelsonAalen`
-- Copula Graphic estimator: `CopulaGraphic`
-- Turnbull estimators: `TurnbullEstimator`, `TurnbullEstimatorLifelines`
-- Fiducial interval-censoring fitter:
-  `SurvivalEVAL.NonparametricEstimator.SingleEvent.Fiducial.fit_fiducial_interval_censor`
+| Method | Description | Code | Paper Link |
+| --- | --- | --- | --- |
+| Kaplan-Meier | Nonparametric estimator of the marginal survival function. | `SingleEvent.KaplanMeier(...)` | [Kaplan and Meier](https://www.jstor.org/stable/2281868) |
+| Kaplan-Meier area | Kaplan-Meier estimator with area/best-guess utilities for censored survival times. | `SingleEvent.KaplanMeierArea(...)` | [Kaplan and Meier](https://www.jstor.org/stable/2281868) |
+| Nelson-Aalen | Nonparametric estimator of the cumulative hazard function. | `SingleEvent.NelsonAalen(...)` | [Nelson](https://www.jstor.org/stable/2958850) |
+| Copula Graphic | Estimates survival under dependent censoring with a specified copula. | `SingleEvent.CopulaGraphic(...)` | [Emura and Chen](https://link.springer.com/book/10.1007/978-981-10-7164-5) |
+| Turnbull | EM estimator for interval-censored survival data. | `SingleEvent.TurnbullEstimator(...)` | [Turnbull](https://www.jstor.org/stable/2285518) |
+| Turnbull lifelines adapter | Lifelines-backed Turnbull estimator wrapper. | `SingleEvent.TurnbullEstimatorLifelines(...)` | [Turnbull](https://www.jstor.org/stable/2285518) |
+| Fiducial interval-censoring fitter | Fiducial estimator for interval-censored CDF samples and summaries. | `SurvivalEVAL.NonparametricEstimator.SingleEvent.Fiducial.fit_fiducial_interval_censor(...)` | N/A |
 
 ## Citing This Work
 

--- a/SurvivalEVAL/Evaluations/AreaUnderPRCurve.py
+++ b/SurvivalEVAL/Evaluations/AreaUnderPRCurve.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Union
+
 import numpy as np
 from scipy.interpolate import interp1d
 
@@ -117,7 +119,7 @@ def auprc_right_censor(
     event_indicators: np.ndarray,
     n_quad: int = 256,
     return_details: bool = False,
-) -> float | tuple[float, np.ndarray]:
+) -> Union[float, tuple[float, np.ndarray]]:
     """
     AUPRC formula for uncensored and right-censored scenarios
 
@@ -193,7 +195,7 @@ def auprc_ic(
     n_quad: int = 256,
     left_extrapolation_value: float = None,
     return_details: bool = False,
-) -> float | tuple[float, np.ndarray]:
+) -> Union[float, tuple[float, np.ndarray]]:
     """
     Per-patient Survival-AUPRC for INTERVAL-censored samples:
         AUPRC([left,right]; F) = ∫_0^1 [ F(right/t) - F(left*t) ] dt

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -1,56 +1,23 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Iterator, Optional
 
 import numpy as np
 
+from SurvivalEVAL.Evaluations._concordance_utils import (
+    _ConcordanceCounts,
+    _check_has_any_pairs,
+    _count_directed_risk_pairs,
+    _finalize_counts,
+    _is_before_tau,
+    _iter_time_blocks,
+    _same_time_pair_weight,
+)
 from SurvivalEVAL.NonparametricEstimator.SingleEvent import (
     KaplanMeier,
     KaplanMeierArea,
     TurnbullEstimatorLifelines,
 )
-
-
-@dataclass
-class ConcordanceCounts:
-    """Raw concordance pair counts before tie-mode finalization.
-
-    Attributes
-    ----------
-    concordant: float
-        Weighted count of comparable pairs with correctly ordered risks.
-    discordant: float
-        Weighted count of comparable pairs with incorrectly ordered risks.
-    risk_tie_pairs: float
-        Weighted count of comparable pairs tied on risk.
-    time_tie_pairs: float
-        Weighted count of same-time event pairs.
-    """
-
-    concordant: float = 0.0
-    discordant: float = 0.0
-    risk_tie_pairs: float = 0.0
-    time_tie_pairs: float = 0.0
-
-    def __iadd__(self, other: "ConcordanceCounts") -> "ConcordanceCounts":
-        """Add another count object in place.
-
-        Parameters
-        ----------
-        other: ConcordanceCounts
-            Concordance counts to add to this object.
-
-        Returns
-        -------
-        ConcordanceCounts
-            This count object after mutation.
-        """
-        self.concordant += other.concordant
-        self.discordant += other.discordant
-        self.risk_tie_pairs += other.risk_tie_pairs
-        self.time_tie_pairs += other.time_tie_pairs
-        return self
 
 
 def concordance(
@@ -225,84 +192,6 @@ def concordance(
     _check_has_any_pairs(counts)
     return _finalize_counts(counts, ties)
 
-
-def _finalize_counts(
-    counts: ConcordanceCounts, ties: str
-) -> tuple[float, float, float]:
-    """Apply the requested tie policy to raw concordance counts.
-
-    Parameters
-    ----------
-    counts: ConcordanceCounts
-        Raw concordance pair counts.
-    ties: str
-        One of ``"None"``, ``"Time"``, ``"Risk"``, or ``"All"``.
-
-    Returns
-    -------
-    c_index: float
-        The concordance index after applying the requested tie policy.
-    concordant_pairs: float
-        The concordant-pair count after applying the requested tie policy.
-    total_pairs: float
-        The total pair count after applying the requested tie policy.
-    """
-    ties = ties.lower()
-
-    concordant_pairs = counts.concordant
-    if ties == "none":
-        total_pairs = counts.concordant + counts.discordant
-    elif ties == "time":
-        total_pairs = counts.concordant + counts.discordant + counts.time_tie_pairs
-        concordant_pairs += 0.5 * counts.time_tie_pairs
-    elif ties == "risk":
-        total_pairs = counts.concordant + counts.discordant + counts.risk_tie_pairs
-        concordant_pairs += 0.5 * counts.risk_tie_pairs
-    elif ties == "all":
-        total_pairs = (
-            counts.concordant
-            + counts.discordant
-            + counts.risk_tie_pairs
-            + counts.time_tie_pairs
-        )
-        concordant_pairs += 0.5 * (counts.risk_tie_pairs + counts.time_tie_pairs)
-    else:
-        error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
-        raise ValueError(error)
-
-    c_index = concordant_pairs / total_pairs if total_pairs != 0 else float("nan")
-    return c_index, concordant_pairs, total_pairs
-
-
-def _check_has_any_pairs(counts: ConcordanceCounts) -> None:
-    """Raise when no comparable or tied-time pairs were counted.
-
-    Parameters
-    ----------
-    counts: ConcordanceCounts
-        Raw concordance pair counts.
-
-    Returns
-    -------
-    None
-
-    Raises
-    ------
-    ValueError
-        If there are no pairs available to estimate concordance.
-    """
-    if (
-        counts.concordant
-        + counts.discordant
-        + counts.risk_tie_pairs
-        + counts.time_tie_pairs
-        == 0
-    ):
-        raise ValueError(
-            "Data has no comparable pairs, cannot estimate concordance index."
-        )
-
-
 def _right_censored_risk_counts(
     event_indicator: np.ndarray,
     event_time: np.ndarray,
@@ -311,7 +200,7 @@ def _right_censored_risk_counts(
     anchor_pair_weights: Optional[np.ndarray] = None,
     tau: Optional[float] = None,
     tied_tol: float = 1e-8,
-) -> ConcordanceCounts:
+) -> _ConcordanceCounts:
     """Count right-censored comparable pairs for a risk score.
 
     Parameters
@@ -336,7 +225,7 @@ def _right_censored_risk_counts(
 
     Returns
     -------
-    ConcordanceCounts
+    _ConcordanceCounts
         Raw concordance counts before tie-mode finalization. ``concordant``,
         ``discordant``, and ``risk_tie_pairs`` count comparable pairs;
         ``time_tie_pairs`` counts same-time event pairs.
@@ -344,7 +233,7 @@ def _right_censored_risk_counts(
     if sample_weights is None:
         sample_weights = np.ones(event_time.shape[0], dtype=float)
 
-    counts = ConcordanceCounts()
+    counts = _ConcordanceCounts()
     for block, later_samples in _iter_time_blocks(event_time):
         if tau is not None and event_time[block[0]] >= tau:
             break
@@ -391,7 +280,7 @@ def _margin_counts(
     partial_weights: np.ndarray,
     tau: Optional[float] = None,
     tied_tol: float = 1e-8,
-) -> ConcordanceCounts:
+) -> _ConcordanceCounts:
     """Count Margin concordance pairs from best-guess times.
 
     Margin first scores all samples as events at their best-guess event times
@@ -420,7 +309,7 @@ def _margin_counts(
 
     Returns
     -------
-    ConcordanceCounts
+    _ConcordanceCounts
         Raw Margin concordance counts before tie-mode finalization.
     """
     counts = _right_censored_risk_counts(
@@ -479,57 +368,6 @@ def _margin_counts(
 
     return counts
 
-
-def _is_before_tau(times: np.ndarray, tau: Optional[float]) -> np.ndarray:
-    """Return a boolean mask for times that pass the strict tau truncation."""
-    if tau is None:
-        return np.ones(times.shape, dtype=bool)
-    return times < tau
-
-
-def _count_directed_risk_pairs(
-    anchor_indices: np.ndarray,
-    candidate_indices: np.ndarray,
-    estimate: np.ndarray,
-    pair_weights: np.ndarray,
-    tied_tol: float = 1e-8,
-) -> ConcordanceCounts:
-    """Count concordance outcomes for directed risk-score pairs.
-
-    Parameters
-    ----------
-    anchor_indices: np.ndarray, shape = (n_pairs,)
-        Sample indices for the earlier or anchor side of each pair.
-    candidate_indices: np.ndarray, shape = (n_pairs,)
-        Sample indices for the later or candidate side of each pair.
-    estimate: np.ndarray, shape = (n_samples,)
-        Risk scores. Higher scores indicate higher risk.
-    pair_weights: np.ndarray, shape = (n_pairs,)
-        Weight for each directed pair.
-    tied_tol: float, optional (default=1e-8)
-        Absolute tolerance for risk-score ties.
-
-    Returns
-    -------
-    ConcordanceCounts
-        Raw concordance counts for the supplied directed pairs.
-    """
-    if anchor_indices.shape[0] == 0:
-        return ConcordanceCounts()
-
-    risk_diff = estimate[candidate_indices] - estimate[anchor_indices]
-    tied = np.absolute(risk_diff) <= tied_tol
-    concordant = (risk_diff < 0) & ~tied
-
-    concordant_weight = pair_weights[concordant].sum()
-    risk_tie_weight = pair_weights[tied].sum()
-    return ConcordanceCounts(
-        concordant=concordant_weight,
-        discordant=pair_weights.sum() - concordant_weight - risk_tie_weight,
-        risk_tie_pairs=risk_tie_weight,
-    )
-
-
 def _iter_comparable_event_pairs(
     event_indicator: np.ndarray,
     event_time: np.ndarray,
@@ -561,57 +399,6 @@ def _iter_comparable_event_pairs(
                     yield np.full(
                         candidate_indices.shape[0], anchor_index, dtype=int
                     ), candidate_indices
-
-
-def _iter_time_blocks(
-    event_time: np.ndarray,
-) -> Iterator[tuple[np.ndarray, np.ndarray]]:
-    """Yield equal-time sample blocks and the samples with later observed times.
-
-    Parameters
-    ----------
-    event_time: np.ndarray, shape = (n_samples,)
-        Observed event or censoring times.
-
-    Yields
-    ------
-    block: np.ndarray
-        Sample indices with the same observed time.
-    later_samples: np.ndarray
-        Sample indices whose observed time is greater than the block time.
-    """
-    order = np.argsort(event_time, kind="stable")
-    n_samples = order.shape[0]
-
-    start = 0
-    while start < n_samples:
-        end = start + 1
-        time_i = event_time[order[start]]
-        while end < n_samples and event_time[order[end]] == time_i:
-            end += 1
-
-        yield order[start:end], order[end:]
-        start = end
-
-
-def _same_time_pair_weight(sample_weights: np.ndarray) -> float:
-    """Return the total pair weight within one same-time event block.
-
-    Parameters
-    ----------
-    sample_weights: np.ndarray
-        Per-sample weights for samples in the same event-time block.
-
-    Returns
-    -------
-    float
-        The sum of pairwise weight products for all unique pairs in the block.
-    """
-    if sample_weights.shape[0] < 2:
-        return 0.0
-    total_weight = sample_weights.sum()
-    return 0.5 * (total_weight * total_weight - np.dot(sample_weights, sample_weights))
-
 
 def _get_comparable_ic(
     left: np.ndarray,

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -5,8 +5,8 @@ from typing import Iterator, Optional
 import numpy as np
 
 from SurvivalEVAL.Evaluations._concordance_utils import (
-    _ConcordanceCounts,
     _check_has_any_pairs,
+    _ConcordanceCounts,
     _count_directed_risk_pairs,
     _finalize_counts,
     _is_before_tau,
@@ -192,6 +192,7 @@ def concordance(
     _check_has_any_pairs(counts)
     return _finalize_counts(counts, ties)
 
+
 def _right_censored_risk_counts(
     event_indicator: np.ndarray,
     event_time: np.ndarray,
@@ -368,6 +369,7 @@ def _margin_counts(
 
     return counts
 
+
 def _iter_comparable_event_pairs(
     event_indicator: np.ndarray,
     event_time: np.ndarray,
@@ -399,6 +401,7 @@ def _iter_comparable_event_pairs(
                     yield np.full(
                         candidate_indices.shape[0], anchor_index, dtype=int
                     ), candidate_indices
+
 
 def _get_comparable_ic(
     left: np.ndarray,

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, Optional
 
 import numpy as np
 
@@ -220,7 +220,7 @@ def concordance(
             tau=tau,
         )
     else:
-        raise TypeError("Method for calculating concordance is unrecognized.")
+        raise ValueError("Method for calculating concordance is unrecognized.")
 
     _check_has_any_pairs(counts)
     return _finalize_counts(counts, ties)
@@ -268,7 +268,7 @@ def _finalize_counts(
         concordant_pairs += 0.5 * (counts.risk_tie_pairs + counts.time_tie_pairs)
     else:
         error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
-        raise TypeError(error)
+        raise ValueError(error)
 
     c_index = concordant_pairs / total_pairs if total_pairs != 0 else float("nan")
     return c_index, concordant_pairs, total_pairs
@@ -869,7 +869,7 @@ def concordance_ic(
 def impute_times_midpoint(
     left: np.ndarray,
     right: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Construct (t, delta) from (left, right] intervals using endpoint/midpoint
     imputation.

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -113,10 +113,10 @@ def concordance(
     -------
     c_index: float
         The concordance index.
-    concordant_pairs: float
+    num_concordant_pairs: float
         The number of concordant pairs.
-    total_pairs: float
-        The total number of comparable pairs.
+    num_total_pairs: float
+        The number of total pairs.
     """
     # the scikit-survival concordance function only takes risk scores to calculate.
     # So at first we should transfer the predicted time -> risk score.

--- a/SurvivalEVAL/Evaluations/DistributionCalibration.py
+++ b/SurvivalEVAL/Evaluations/DistributionCalibration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -153,7 +153,7 @@ def ksd_calibration(
     pred_probs: np.ndarray,
     event_indicators: np.ndarray,
     return_details: bool = False,
-) -> tuple[float, float] | tuple[float, dict]:
+) -> Union[tuple[float, float], tuple[float, dict]]:
     """
     Calculate the K-S D-Calibration score.
 
@@ -483,7 +483,7 @@ def km_calibration(
     event_indicators: np.ndarray,
     interpolation_method: str = "Linear",
     draw_figure: bool = False,
-) -> float | tuple[float, tuple[plt.Figure, plt.Axes]]:
+) -> Union[float, tuple[float, tuple[plt.Figure, plt.Axes]]]:
     """
     Calculate the KM calibration score between the average prediction curve and KM curve.
     The first version of KM calibration [1] is by visual inspection of the KM curve and the average curve.

--- a/SurvivalEVAL/Evaluations/OtherMetrics.py
+++ b/SurvivalEVAL/Evaluations/OtherMetrics.py
@@ -10,7 +10,7 @@ Description:
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from typing import Sequence
 
 import numpy as np
 from scipy.optimize import brentq
@@ -63,7 +63,7 @@ def calibration_slope_right_censor(
     *,
     quantile_method: str = "Linear",  # "Linear"|"Pchip"
     through_origin: bool = True,
-) -> Tuple[np.ndarray, np.ndarray, float]:
+) -> tuple[np.ndarray, np.ndarray, float]:
     """
     right uncensor (p, obs(p))：
       - event count=1{t_ip >= y_i}
@@ -135,7 +135,7 @@ def calibration_slope_interval_censor(
     quantile_method: str = "Linear",  # "Linear" | "Pchip"  (for survival interpolator)
     through_origin: bool = True,  # fit slope through origin (default in paper)
     clip_p: float = 1e-6,
-) -> Tuple[np.ndarray, np.ndarray, float]:
+) -> tuple[np.ndarray, np.ndarray, float]:
     """
     Compute calibration points (p, obs(p)) and slope under INTERVAL censoring:
       - Include as 1 if t_{i,p} >= U_i
@@ -201,7 +201,7 @@ def calibration_slope_interval_censor(
 
 def cov(
     cdf: np.ndarray, t_grid: np.ndarray, return_details: bool = False
-) -> float | Tuple[float, np.ndarray]:
+) -> float | tuple[float, np.ndarray]:
     """
     Compute the coefficient of variation of event time from a discretized CDF.
 

--- a/SurvivalEVAL/Evaluations/OtherMetrics.py
+++ b/SurvivalEVAL/Evaluations/OtherMetrics.py
@@ -10,7 +10,7 @@ Description:
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Sequence, Union
 
 import numpy as np
 from scipy.optimize import brentq
@@ -201,7 +201,7 @@ def calibration_slope_interval_censor(
 
 def cov(
     cdf: np.ndarray, t_grid: np.ndarray, return_details: bool = False
-) -> float | tuple[float, np.ndarray]:
+) -> Union[float, tuple[float, np.ndarray]]:
     """
     Compute the coefficient of variation of event time from a discretized CDF.
 

--- a/SurvivalEVAL/Evaluations/SingleTimeCalibration.py
+++ b/SurvivalEVAL/Evaluations/SingleTimeCalibration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Union
+
 import matplotlib.pyplot as plt  # For plotting
 import numpy as np
 import pandas as pd
@@ -285,7 +287,7 @@ def integrated_calibration_index(
     knots: int = 3,
     draw_figure: bool = False,
     figure_range: tuple = None,
-) -> dict | tuple[dict, tuple[plt.Figure, plt.Axes]]:
+) -> Union[dict, tuple[dict, tuple[plt.Figure, plt.Axes]]]:
     """
     Compute the Integrated Calibration Index (ICI) for a given set of predictions and true event times.
     The method is presented in [1]. The implementation is based on the R code available in Appendix A of [1].

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+def concordance_time_dependent(
+    risk_scores: np.ndarray,
+    event_times: np.ndarray,
+    event_indicators: np.ndarray,
+    train_event_times: Optional[np.ndarray] = None,
+    train_event_indicators: Optional[np.ndarray] = None,
+    method: str = "Antolini",
+    ties: str = "Risk",
+    tau: Optional[float] = None,
+) -> tuple[float, float, float]:
+    """
+    Calculate the time-dependent concordance index between the predicted risk scores and the true survival times.
+
+    Parameters
+    ----------
+    risk_scores: np.ndarray, shape = (n_samples, n_anchor_times)
+        The predicted risk scores for each sample at each anchor time.
+        The risk scores should be ordered such that higher scores indicate higher risk
+        (i.e., lower survival probability or lower hazard score).
+    event_times: np.ndarray, shape = (n_samples,)
+        The true survival times.
+    event_indicators: np.ndarray, shape = (n_samples,)
+        Binary event indicators: 1 denotes an observed event and 0 denotes a
+        censored observation.
+    train_event_times: np.ndarray, shape = (n_train_samples,), optional
+        The true survival times of the training set. Required for "IPCW".
+    train_event_indicators: np.ndarray, shape = (n_train_samples,), optional
+        Binary training-set event indicators: 1 denotes an observed event and
+        0 denotes a censored observation. Required for "IPCW".
+    method: str, optional (default="Antolini")
+        A string indicating the method for constructing the pairs of samples.
+        Options are "Antolini" (default), "Naive", or "IPCW".
+        "Antolini": comparable pairs are anchored by samples with observed
+        events. If sample i has an observed event at time t_i, it is compared
+        with samples whose observed event/censoring time is greater than t_i.
+        "Naive": alias of "Antolini".
+        "IPCW": Antolini-style comparable pairs weighted by inverse probability
+        of censoring weights from the training data.
+    ties: str, optional (default="Risk")
+        A string indicating the way ties should be handled.
+        Options: "None", "Time", "Risk" (default), or "All"
+    tau: float, optional
+        The time horizon for the time-dependent concordance index. If None,
+        the maximum observed time is used.
+
+    Returns
+    -------
+    c_index: float
+        The concordance index.
+    num_concordant_pairs: float
+        The number of concordant pairs.
+    num_total_pairs: float
+        The number of total pairs.
+    """
+    event_indicators = event_indicators.astype(bool)
+
+    if risk_scores.ndim != 2:
+        raise ValueError(
+            f"risk_scores should be a 2D array of shape (n_samples, n_anchor_times), but got shape {risk_scores.shape}."
+        )
+
+    # check if the predicted risk scores has the dimension of (n_samples, n_anchor_times)
+    n_samples, n_anchor_times = risk_scores.shape
+    assert (
+        n_samples == len(event_times) == len(event_indicators)
+    ), "The lengths of the predicted times and labels must be the same."
+
+    assert (
+        n_anchor_times == event_indicators.sum()
+    ), "The number of anchor times (columns in risk_scores) must match the number of observed events."
+
+    method = method.lower()
+    ties = ties.lower()
+
+    if method == "antolini" or method == "naive":
+        raise NotImplementedError("Antolini's method for time-dependent concordance index is not yet implemented.")
+    elif method == "ipcw":
+        if train_event_times is None or train_event_indicators is None:
+            raise ValueError("train_event_times and train_event_indicators must be provided for IPCW method.")
+        raise NotImplementedError("IPCW method for time-dependent concordance index is not yet implemented.")
+    else:
+        raise ValueError(f"Unsupported method: {method}. Supported methods are 'Antolini', 'Naive', and 'IPCW'.")

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -4,6 +4,17 @@ from typing import Optional
 
 import numpy as np
 
+from SurvivalEVAL.Evaluations._concordance_utils import (
+    _ConcordanceCounts,
+    _check_has_any_pairs,
+    _count_directed_risk_pairs,
+    _finalize_counts,
+    _is_before_tau,
+    _iter_time_blocks,
+    _same_time_pair_weight,
+)
+from SurvivalEVAL.NonparametricEstimator.SingleEvent import KaplanMeier
+
 
 def concordance_time_dependent(
     risk_scores: np.ndarray,
@@ -24,6 +35,9 @@ def concordance_time_dependent(
         The predicted risk scores for each sample at each anchor time.
         The risk scores should be ordered such that higher scores indicate higher risk
         (i.e., lower survival probability or higher hazard score).
+        ``risk_scores[i, k]`` is the risk score for test sample ``i``
+        evaluated at the kth observed-event anchor time. The kth anchor time
+        corresponds to ``event_times[np.flatnonzero(event_indicators)[k]]``.
     event_times: np.ndarray, shape = (n_samples,)
         The true survival times.
     event_indicators: np.ndarray, shape = (n_samples,)
@@ -47,8 +61,8 @@ def concordance_time_dependent(
         A string indicating the way ties should be handled.
         Options: "None", "Time", "Risk" (default), or "All"
     tau: float, optional
-        The time horizon for the time-dependent concordance index. If None,
-        the maximum observed time is used.
+        Truncation time. If provided, only event anchors whose observed time is
+        strictly before ``tau`` are counted. If None, no truncation is applied.
 
     Returns
     -------
@@ -65,25 +79,173 @@ def concordance_time_dependent(
         raise ValueError(
             f"risk_scores should be a 2D array of shape (n_samples, n_anchor_times), but got shape {risk_scores.shape}."
         )
+    if event_times.ndim != 1 or event_indicators.ndim != 1:
+        raise ValueError("event_times and event_indicators must be 1-D arrays.")
 
     # check if the predicted risk scores has the dimension of (n_samples, n_anchor_times)
     n_samples, n_anchor_times = risk_scores.shape
-    assert (
-        n_samples == len(event_times) == len(event_indicators)
-    ), "The lengths of the predicted times and labels must be the same."
+    if not (n_samples == event_times.shape[0] == event_indicators.shape[0]):
+        raise ValueError(
+            "The lengths of risk_scores, event_times, and event_indicators must be the same."
+        )
 
-    assert (
-        n_anchor_times == event_indicators.sum()
-    ), "The number of anchor times (columns in risk_scores) must match the number of observed events."
+    n_observed_events = int(event_indicators.sum())
+    if n_observed_events == 0:
+        raise ValueError(
+            "Data has no observed events, cannot estimate time-dependent concordance index."
+        )
+    if n_anchor_times != n_observed_events:
+        raise ValueError(
+            "The number of anchor times (columns in risk_scores) must match the number of observed events."
+        )
 
     method = method.lower()
     ties = ties.lower()
 
     if method == "antolini" or method == "naive":
-        raise NotImplementedError("Antolini's method for time-dependent concordance index is not yet implemented.")
+        sample_weights = None
+        anchor_pair_weights = None
     elif method == "ipcw":
         if train_event_times is None or train_event_indicators is None:
-            raise ValueError("train_event_times and train_event_indicators must be provided for IPCW method.")
-        raise NotImplementedError("IPCW method for time-dependent concordance index is not yet implemented.")
+            raise ValueError(
+                "train_event_times and train_event_indicators must be provided for IPCW method."
+            )
+        train_event_indicators = train_event_indicators.astype(bool)
+
+        censoring_model = KaplanMeier(train_event_times, ~train_event_indicators)
+        censoring_survival = censoring_model.predict(event_times)
+        observed_anchors = event_indicators & _is_before_tau(event_times, tau)
+
+        # IPCW only needs positive censoring survival for event anchors whose
+        # weights can affect the selected concordance result. Every non-final
+        # event-time block has later samples as candidates. In the final block,
+        # event anchors still contribute through same-time censored candidates;
+        # event-event time ties contribute only when the requested tie policy
+        # keeps time ties. Otherwise final events have no effect on the returned
+        # index, so exclude them from the zero-survival check and weight
+        # assignment.
+        final_time = np.max(event_times)
+        final_block = event_times == final_time
+        final_events = final_block & event_indicators
+        final_event_count = np.count_nonzero(final_events)
+        final_has_censored_candidate = np.any(final_block & ~event_indicators)
+        final_time_ties_counted = ties in {"time", "all"}
+        final_events_contribute = final_has_censored_candidate or (
+            final_time_ties_counted and final_event_count > 1
+        )
+        if not final_events_contribute:
+            observed_anchors[final_events] = False
+
+        if np.any(censoring_survival[observed_anchors] <= 0):
+            raise ValueError(
+                "Censoring survival probability is zero for at least one observed event; "
+                "choose a smaller tau."
+            )
+
+        sample_weights = np.zeros_like(event_times, dtype=float)
+        sample_weights[observed_anchors] = 1 / censoring_survival[observed_anchors]
+
+        anchor_pair_weights = np.zeros_like(event_times, dtype=float)
+        anchor_pair_weights[observed_anchors] = 1 / np.square(
+            censoring_survival[observed_anchors]
+        )
     else:
-        raise ValueError(f"Unsupported method: {method}. Supported methods are 'Antolini', 'Naive', and 'IPCW'.")
+        raise ValueError(
+            f"Unsupported method: {method}. Supported methods are 'Antolini', 'Naive', and 'IPCW'."
+        )
+
+    counts = _time_dependent_risk_counts(
+        risk_scores=risk_scores,
+        event_times=event_times,
+        event_indicators=event_indicators,
+        sample_weights=sample_weights,
+        anchor_pair_weights=anchor_pair_weights,
+        tau=tau,
+    )
+
+    _check_has_any_pairs(counts)
+    return _finalize_counts(counts, ties)
+
+
+def _time_dependent_risk_counts(
+    risk_scores: np.ndarray,
+    event_times: np.ndarray,
+    event_indicators: np.ndarray,
+    sample_weights: Optional[np.ndarray] = None,
+    anchor_pair_weights: Optional[np.ndarray] = None,
+    tau: Optional[float] = None,
+    tied_tol: float = 1e-8,
+) -> _ConcordanceCounts:
+    """Count Antolini-style time-dependent concordance pairs.
+
+    Parameters
+    ----------
+    risk_scores: np.ndarray, shape = (n_samples, n_observed_events)
+        Risk scores evaluated at observed-event anchor times. Higher scores
+        indicate higher event risk.
+    event_times: np.ndarray, shape = (n_samples,)
+        Observed event or censoring times.
+    event_indicators: np.ndarray, shape = (n_samples,)
+        Boolean event indicators, where True denotes an observed event.
+    sample_weights: np.ndarray, shape = (n_samples,), optional
+        Optional symmetric sample weights used for same-time event ties and,
+        unless ``anchor_pair_weights`` is provided, comparable pair weights.
+    anchor_pair_weights: np.ndarray, shape = (n_samples,), optional
+        Optional per-anchor pair weights. If provided, every comparable pair
+        anchored by sample ``i`` receives ``anchor_pair_weights[i]``.
+    tau: float, optional (default=None)
+        Truncation time. If provided, only event anchors whose observed time is
+        strictly before ``tau`` are counted. If None, no truncation is applied.
+    tied_tol: float, optional (default=1e-8)
+        Absolute tolerance for risk-score ties.
+
+    Returns
+    -------
+    _ConcordanceCounts
+        Raw concordance counts before tie-mode finalization.
+    """
+    if sample_weights is None:
+        sample_weights = np.ones(event_times.shape[0], dtype=float)
+
+    anchor_indices = np.flatnonzero(event_indicators)
+    anchor_col_by_sample = np.full(event_times.shape[0], -1, dtype=int)
+    anchor_col_by_sample[anchor_indices] = np.arange(anchor_indices.shape[0])
+
+    counts = _ConcordanceCounts()
+    for block, later_samples in _iter_time_blocks(event_times):
+        if tau is not None and event_times[block[0]] >= tau:
+            break
+
+        event_anchors = block[event_indicators[block]]
+        if event_anchors.shape[0] == 0:
+            continue
+
+        counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
+
+        candidate_indices = np.concatenate(
+            (block[~event_indicators[block]], later_samples)
+        )
+        if candidate_indices.shape[0] == 0:
+            continue
+
+        for anchor_index in event_anchors:
+            anchor_col = anchor_col_by_sample[anchor_index]
+            if anchor_pair_weights is None:
+                pair_weights = (
+                    sample_weights[anchor_index] * sample_weights[candidate_indices]
+                )
+            else:
+                pair_weights = np.full(
+                    candidate_indices.shape[0],
+                    anchor_pair_weights[anchor_index],
+                    dtype=float,
+                )
+            counts += _count_directed_risk_pairs(
+                np.full(candidate_indices.shape[0], anchor_index, dtype=int),
+                candidate_indices,
+                risk_scores[:, anchor_col],
+                pair_weights=pair_weights,
+                tied_tol=tied_tol,
+            )
+
+    return counts

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -5,8 +5,8 @@ from typing import Optional
 import numpy as np
 
 from SurvivalEVAL.Evaluations._concordance_utils import (
-    _ConcordanceCounts,
     _check_has_any_pairs,
+    _ConcordanceCounts,
     _count_directed_risk_pairs,
     _finalize_counts,
     _is_before_tau,

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -38,6 +38,10 @@ def concordance_time_dependent(
         ``risk_scores[i, k]`` is the risk score for test sample ``i``
         evaluated at the kth observed-event anchor time. The kth anchor time
         corresponds to ``event_times[np.flatnonzero(event_indicators)[k]]``.
+        Anchor times are sample-level observed events, not unique event times.
+        If multiple observed events share the same time, ``risk_scores`` must
+        include one column for each of those samples in observed-event sample
+        order.
     event_times: np.ndarray, shape = (n_samples,)
         The true survival times.
     event_indicators: np.ndarray, shape = (n_samples,)

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -23,7 +23,7 @@ def concordance_time_dependent(
     risk_scores: np.ndarray, shape = (n_samples, n_anchor_times)
         The predicted risk scores for each sample at each anchor time.
         The risk scores should be ordered such that higher scores indicate higher risk
-        (i.e., lower survival probability or lower hazard score).
+        (i.e., lower survival probability or higher hazard score).
     event_times: np.ndarray, shape = (n_samples,)
         The true survival times.
     event_indicators: np.ndarray, shape = (n_samples,)

--- a/SurvivalEVAL/Evaluations/_concordance_utils.py
+++ b/SurvivalEVAL/Evaluations/_concordance_utils.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+import numpy as np
+
+
+@dataclass
+class _ConcordanceCounts:
+    """Raw concordance pair counts before tie-mode finalization.
+
+    Attributes
+    ----------
+    concordant: float
+        Weighted count of comparable pairs with correctly ordered risks.
+    discordant: float
+        Weighted count of comparable pairs with incorrectly ordered risks.
+    risk_tie_pairs: float
+        Weighted count of comparable pairs tied on risk.
+    time_tie_pairs: float
+        Weighted count of same-time event pairs.
+    """
+
+    concordant: float = 0.0
+    discordant: float = 0.0
+    risk_tie_pairs: float = 0.0
+    time_tie_pairs: float = 0.0
+
+    def __iadd__(self, other: "_ConcordanceCounts") -> "_ConcordanceCounts":
+        """Add another count object in place.
+
+        Parameters
+        ----------
+        other: _ConcordanceCounts
+            Concordance counts to add to this object.
+
+        Returns
+        -------
+        _ConcordanceCounts
+            This count object after mutation.
+        """
+        self.concordant += other.concordant
+        self.discordant += other.discordant
+        self.risk_tie_pairs += other.risk_tie_pairs
+        self.time_tie_pairs += other.time_tie_pairs
+        return self
+
+
+def _finalize_counts(
+    counts: _ConcordanceCounts, ties: str
+) -> tuple[float, float, float]:
+    """Apply the requested tie policy to raw concordance counts.
+
+    Parameters
+    ----------
+    counts: _ConcordanceCounts
+        Raw concordance pair counts.
+    ties: str
+        One of ``"None"``, ``"Time"``, ``"Risk"``, or ``"All"``.
+
+    Returns
+    -------
+    c_index: float
+        The concordance index after applying the requested tie policy.
+    concordant_pairs: float
+        The concordant-pair count after applying the requested tie policy.
+    total_pairs: float
+        The total pair count after applying the requested tie policy.
+    """
+    ties = ties.lower()
+
+    concordant_pairs = counts.concordant
+    if ties == "none":
+        total_pairs = counts.concordant + counts.discordant
+    elif ties == "time":
+        total_pairs = counts.concordant + counts.discordant + counts.time_tie_pairs
+        concordant_pairs += 0.5 * counts.time_tie_pairs
+    elif ties == "risk":
+        total_pairs = counts.concordant + counts.discordant + counts.risk_tie_pairs
+        concordant_pairs += 0.5 * counts.risk_tie_pairs
+    elif ties == "all":
+        total_pairs = (
+            counts.concordant
+            + counts.discordant
+            + counts.risk_tie_pairs
+            + counts.time_tie_pairs
+        )
+        concordant_pairs += 0.5 * (counts.risk_tie_pairs + counts.time_tie_pairs)
+    else:
+        error = "Please enter one of 'None', 'Time', 'Risk', or 'All' for handling ties for concordance."
+        raise ValueError(error)
+
+    c_index = concordant_pairs / total_pairs if total_pairs != 0 else float("nan")
+    return c_index, concordant_pairs, total_pairs
+
+
+def _check_has_any_pairs(counts: _ConcordanceCounts) -> None:
+    """Raise when no comparable or tied-time pairs were counted.
+
+    Parameters
+    ----------
+    counts: _ConcordanceCounts
+        Raw concordance pair counts.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If there are no pairs available to estimate concordance.
+    """
+    if (
+        counts.concordant
+        + counts.discordant
+        + counts.risk_tie_pairs
+        + counts.time_tie_pairs
+        == 0
+    ):
+        raise ValueError(
+            "Data has no comparable pairs, cannot estimate concordance index."
+        )
+
+
+def _is_before_tau(times: np.ndarray, tau: Optional[float]) -> np.ndarray:
+    """Return a boolean mask for times that pass the strict tau truncation."""
+    if tau is None:
+        return np.ones(times.shape, dtype=bool)
+    return times < tau
+
+
+def _count_directed_risk_pairs(
+    anchor_indices: np.ndarray,
+    candidate_indices: np.ndarray,
+    estimate: np.ndarray,
+    pair_weights: np.ndarray,
+    tied_tol: float = 1e-8,
+) -> _ConcordanceCounts:
+    """Count concordance outcomes for directed risk-score pairs.
+
+    Parameters
+    ----------
+    anchor_indices: np.ndarray, shape = (n_pairs,)
+        Sample indices for the earlier or anchor side of each pair.
+    candidate_indices: np.ndarray, shape = (n_pairs,)
+        Sample indices for the later or candidate side of each pair.
+    estimate: np.ndarray, shape = (n_samples,)
+        Risk scores. Higher scores indicate higher risk.
+    pair_weights: np.ndarray, shape = (n_pairs,)
+        Weight for each directed pair.
+    tied_tol: float, optional (default=1e-8)
+        Absolute tolerance for risk-score ties.
+
+    Returns
+    -------
+    _ConcordanceCounts
+        Raw concordance counts for the supplied directed pairs.
+    """
+    if anchor_indices.shape[0] == 0:
+        return _ConcordanceCounts()
+
+    risk_diff = estimate[candidate_indices] - estimate[anchor_indices]
+    tied = np.absolute(risk_diff) <= tied_tol
+    concordant = (risk_diff < 0) & ~tied
+
+    concordant_weight = pair_weights[concordant].sum()
+    risk_tie_weight = pair_weights[tied].sum()
+    return _ConcordanceCounts(
+        concordant=concordant_weight,
+        discordant=pair_weights.sum() - concordant_weight - risk_tie_weight,
+        risk_tie_pairs=risk_tie_weight,
+    )
+
+
+def _iter_time_blocks(
+    event_time: np.ndarray,
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Yield equal-time sample blocks and the samples with later observed times.
+
+    Parameters
+    ----------
+    event_time: np.ndarray, shape = (n_samples,)
+        Observed event or censoring times.
+
+    Yields
+    ------
+    block: np.ndarray
+        Sample indices with the same observed time.
+    later_samples: np.ndarray
+        Sample indices whose observed time is greater than the block time.
+    """
+    order = np.argsort(event_time, kind="stable")
+    n_samples = order.shape[0]
+
+    start = 0
+    while start < n_samples:
+        end = start + 1
+        time_i = event_time[order[start]]
+        while end < n_samples and event_time[order[end]] == time_i:
+            end += 1
+
+        yield order[start:end], order[end:]
+        start = end
+
+
+def _same_time_pair_weight(sample_weights: np.ndarray) -> float:
+    """Return the total pair weight within one same-time event block.
+
+    Parameters
+    ----------
+    sample_weights: np.ndarray
+        Per-sample weights for samples in the same event-time block.
+
+    Returns
+    -------
+    float
+        The sum of pairwise weight products for all unique pairs in the block.
+    """
+    if sample_weights.shape[0] < 2:
+        return 0.0
+    total_weight = sample_weights.sum()
+    return 0.5 * (total_weight * total_weight - np.dot(sample_weights, sample_weights))

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -83,6 +83,52 @@ def check_and_convert(*args):
     return result
 
 
+def validate_time_points(
+    time_points,
+    input_name: str = "target_times",
+    allow_scalar: bool = False,
+) -> np.ndarray:
+    """Validate nonnegative scalar or one-dimensional time inputs.
+
+    Parameters
+    ----------
+    time_points
+        Time point input to validate.
+    input_name : str, default="target_times"
+        Name used in validation error messages.
+    allow_scalar : bool, default=False
+        Whether a scalar time point is accepted. Scalars are returned as a
+        one-element array.
+
+    Returns
+    -------
+    np.ndarray
+        One-dimensional array of nonnegative time points.
+
+    Raises
+    ------
+    ValueError
+        If the input is scalar when scalars are not allowed, is not
+        one-dimensional, or contains negative values.
+    """
+    is_scalar = np.isscalar(time_points) or (
+        isinstance(time_points, np.ndarray) and time_points.ndim == 0
+    )
+    if is_scalar:
+        if not allow_scalar:
+            raise ValueError(f"{input_name} must be a 1-D array.")
+        time_points = np.asarray([time_points], dtype=float)
+    else:
+        time_points = check_and_convert(time_points).astype(float)
+
+    if time_points.ndim != 1:
+        raise ValueError(f"{input_name} must be a 1-D array.")
+    if np.any(time_points < 0):
+        raise ValueError(f"{input_name} must be non-negative.")
+
+    return time_points
+
+
 def check_monotonicity(
     array: NumericArrayLike,
     direction: str | None = None,
@@ -299,9 +345,14 @@ def predict_prob_from_curve(
     survival_curve, times_coordinate = zero_padding(survival_curve, times_coordinate)
     if survival_curve.ndim != 1 or times_coordinate.ndim != 1:
         raise ValueError("survival_curve and times_coordinate must be 1-D arrays.")
-    target_time = float(target_time)
-    if target_time < 0:
-        raise ValueError("target_time must be non-negative.")
+    target_time = validate_time_points(
+        target_time,
+        input_name="target_time",
+        allow_scalar=True,
+    )
+    if target_time.shape[0] != 1:
+        raise ValueError("target_time must contain exactly one time point.")
+    target_time = float(target_time[0])
 
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 
@@ -359,11 +410,7 @@ def predict_multi_probs_from_curve(
     survival_curve, times_coordinate = zero_padding(survival_curve, times_coordinate)
     if survival_curve.ndim != 1 or times_coordinate.ndim != 1:
         raise ValueError("survival_curve and times_coordinate must be 1-D arrays.")
-    target_times = check_and_convert(target_times).astype(float)
-    if target_times.ndim != 1:
-        raise ValueError("target_times must be a 1-D array.")
-    if np.any(target_times < 0):
-        raise ValueError("target_times must be non-negative.")
+    target_times = validate_time_points(target_times, input_name="target_times")
 
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 
@@ -545,7 +592,8 @@ def predict_mean_st(
     last_time = time_grids[:, -1]
     # the residual area is calculated as the area of a triangle with height = last_prob
     # and base = extrapolation_time - last_time
-    # extrapolation_time is the time point where the survival curve crosses 0 (using the linear function of [0, 1] - [last_time, last_prob])
+    # extrapolation_time is the time point where the survival curve crosses 0
+    # using the linear function of [0, 1] - [last_time, last_prob].
     residual_area = 0.5 * last_prob**2 * last_time / (1 - last_prob)
     mean_st = rmst + residual_area
     return float(mean_st[0]) if scalar_output else mean_st

--- a/SurvivalEVAL/Evaluations/util.py
+++ b/SurvivalEVAL/Evaluations/util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -83,22 +83,65 @@ def check_and_convert(*args):
     return result
 
 
+def validate_time_point(
+    time_point: Union[int, float],
+    input_name: str = "target_time",
+) -> float:
+    """Validate a nonnegative scalar time input.
+
+    Parameters
+    ----------
+    time_point
+        Scalar time point input to validate.
+    input_name : str, default="target_time"
+        Name used in validation error messages.
+
+    Returns
+    -------
+    float
+        Nonnegative time point.
+
+    Raises
+    ------
+    TypeError
+        If the input is not a numeric scalar.
+    ValueError
+        If the scalar time point is negative.
+    """
+    is_scalar = np.isscalar(time_point) or (
+        isinstance(time_point, np.ndarray) and time_point.ndim == 0
+    )
+    is_numeric_scalar = isinstance(
+        time_point, (int, float, np.integer, np.floating)
+    ) or (
+        isinstance(time_point, np.ndarray)
+        and (
+            np.issubdtype(time_point.dtype, np.integer)
+            or np.issubdtype(time_point.dtype, np.floating)
+        )
+    )
+    if not is_scalar or not is_numeric_scalar:
+        raise TypeError(f"{input_name} must be a numeric scalar.")
+
+    time_point = float(np.asarray(time_point, dtype=float))
+    if time_point < 0:
+        raise ValueError(f"{input_name} must be non-negative.")
+
+    return time_point
+
+
 def validate_time_points(
-    time_points,
+    time_points: NumericArrayLike,
     input_name: str = "target_times",
-    allow_scalar: bool = False,
 ) -> np.ndarray:
-    """Validate nonnegative scalar or one-dimensional time inputs.
+    """Validate one-dimensional nonnegative time inputs.
 
     Parameters
     ----------
     time_points
-        Time point input to validate.
+        One-dimensional time point input to validate.
     input_name : str, default="target_times"
         Name used in validation error messages.
-    allow_scalar : bool, default=False
-        Whether a scalar time point is accepted. Scalars are returned as a
-        one-element array.
 
     Returns
     -------
@@ -108,18 +151,15 @@ def validate_time_points(
     Raises
     ------
     ValueError
-        If the input is scalar when scalars are not allowed, is not
-        one-dimensional, or contains negative values.
+        If the input is scalar, is not one-dimensional, or contains negative values.
     """
     is_scalar = np.isscalar(time_points) or (
         isinstance(time_points, np.ndarray) and time_points.ndim == 0
     )
     if is_scalar:
-        if not allow_scalar:
-            raise ValueError(f"{input_name} must be a 1-D array.")
-        time_points = np.asarray([time_points], dtype=float)
-    else:
-        time_points = check_and_convert(time_points).astype(float)
+        raise ValueError(f"{input_name} must be a 1-D array.")
+
+    time_points = check_and_convert(time_points).astype(float)
 
     if time_points.ndim != 1:
         raise ValueError(f"{input_name} must be a 1-D array.")
@@ -131,7 +171,7 @@ def validate_time_points(
 
 def check_monotonicity(
     array: NumericArrayLike,
-    direction: str | None = None,
+    direction: Optional[str] = None,
 ) -> bool:
     """
     Check whether values are monotonic along the last axis.
@@ -311,7 +351,7 @@ def interpolated_curve(
 def predict_prob_from_curve(
     survival_curve: np.ndarray,
     times_coordinate: np.ndarray,
-    target_time: float,
+    target_time: Union[int, float],
     interpolation: str = "Linear",
 ) -> float:
     """
@@ -330,7 +370,7 @@ def predict_prob_from_curve(
         Time points corresponding to the survival curve. 1-D array of time
         points. Values must be non-negative. If the first value is greater than
         0, `(0, 1)` is prepended to the curve.
-    target_time: float
+    target_time: int or float
         Non-negative time point at which to predict the probability of survival.
     interpolation: str
         The monotonic cubic interpolation method. One of ['Linear', 'Pchip']. Default: 'Linear'.
@@ -345,14 +385,10 @@ def predict_prob_from_curve(
     survival_curve, times_coordinate = zero_padding(survival_curve, times_coordinate)
     if survival_curve.ndim != 1 or times_coordinate.ndim != 1:
         raise ValueError("survival_curve and times_coordinate must be 1-D arrays.")
-    target_time = validate_time_points(
+    target_time = validate_time_point(
         target_time,
         input_name="target_time",
-        allow_scalar=True,
     )
-    if target_time.shape[0] != 1:
-        raise ValueError("target_time must contain exactly one time point.")
-    target_time = float(target_time[0])
 
     spline = interpolated_curve(times_coordinate, survival_curve, interpolation)
 

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC
 from functools import cached_property
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -30,6 +30,7 @@ from SurvivalEVAL.Evaluations.SingleTimeCalibration import (
     integrated_calibration_index,
     one_calibration,
 )
+from SurvivalEVAL.Evaluations.TimeDependentConcordance import concordance_time_dependent
 from SurvivalEVAL.Evaluations.util import (
     align_curve_and_time_coordinates,
     check_and_convert,
@@ -128,6 +129,24 @@ class SurvivalEvaluator:
         time_coordinates: np.ndarray,
         n_samples: int,
     ):
+        """Validate that prediction inputs have one row per testing sample.
+
+        Parameters
+        ----------
+        pred_survs : np.ndarray
+            Predicted survival curves, either shared across samples or one row
+            per sample.
+        time_coordinates : np.ndarray
+            Time coordinates, either shared across samples or one row per sample.
+        n_samples : int
+            Expected number of testing samples.
+
+        Raises
+        ------
+        ValueError
+            If a 2-D prediction input has a row count different from
+            ``n_samples``.
+        """
         sample_counts = {}
         if pred_survs.ndim == 2:
             sample_counts["pred_survs"] = pred_survs.shape[0]
@@ -145,6 +164,34 @@ class SurvivalEvaluator:
                 "The number of prediction rows must match the number of testing "
                 f"samples ({n_samples}); {count_details}."
             )
+
+    @staticmethod
+    def _validate_prediction_curve_inputs(
+        pred_survs: np.ndarray,
+        time_coordinates: np.ndarray,
+    ):
+        """Validate survival-curve probability and time-grid invariants.
+
+        Parameters
+        ----------
+        pred_survs : np.ndarray
+            Predicted survival probabilities after any zero-padding.
+        time_coordinates : np.ndarray
+            Time coordinates after any zero-padding.
+
+        Raises
+        ------
+        ValueError
+            If time coordinates are not strictly increasing along each row, if
+            survival probabilities are outside ``[0, 1]``, or if survival curves
+            increase over time.
+        """
+        if np.any(np.diff(time_coordinates, axis=-1) <= 0):
+            raise ValueError("Each row of time_coordinates must be strictly increasing.")
+        if np.any((pred_survs < 0) | (pred_survs > 1)):
+            raise ValueError("Survival probabilities must be between 0 and 1.")
+        if np.any(np.diff(pred_survs, axis=-1) > 1e-8):
+            raise ValueError("Survival probabilities must be nonincreasing.")
 
     def _testing_sample_count(self) -> int:
         if hasattr(self, "left_limits"):
@@ -179,6 +226,7 @@ class SurvivalEvaluator:
         self._pred_survs, self._time_coordinates = zero_padding(
             pred_survs, time_coordinates
         )
+        self._validate_prediction_curve_inputs(self._pred_survs, self._time_coordinates)
         self.ndim_surv = self._pred_survs.ndim
         self.ndim_time = self._time_coordinates.ndim
         self._clear_cache()
@@ -398,6 +446,63 @@ class SurvivalEvaluator:
             raise TypeError("Dimensional error")
 
         return prob_mat
+
+    def predict_multi_hazards_from_curve(self, target_times: np.ndarray) -> np.ndarray:
+        """
+        Calculate piecewise constant hazard rates at multiple time points from
+        the predicted survival curves.
+
+        Parameters
+        ----------
+        target_times: np.ndarray, shape = (n_target_times)
+            Time points at which the hazard rates are to be predicted.
+
+        Returns
+        -------
+        hazard_mat: np.ndarray, shape = (n_samples, n_target_times)
+            Predicted hazard rates at the target time points.
+        """
+        target_times = check_and_convert(target_times).astype(float)
+        if target_times.ndim != 1:
+            raise ValueError("target_times must be a 1-D array.")
+        if np.any(target_times < 0):
+            raise ValueError("target_times must be non-negative.")
+
+        survival_curves, time_grids = align_curve_and_time_coordinates(
+            self._pred_survs,
+            self._time_coordinates,
+            n_samples=self._testing_sample_count(),
+        )
+        if survival_curves.shape[1] < 2:
+            raise ValueError(
+                "At least two time points are required to estimate hazards."
+            )
+
+        hazard_mat = np.empty(
+            (survival_curves.shape[0], target_times.shape[0]), dtype=float
+        )
+        eps = 1e-12
+
+        for i, (survival_curve, time_grid) in enumerate(
+            zip(survival_curves, time_grids)
+        ):
+            if np.any(target_times > time_grid[-1]):
+                raise ValueError(
+                    "target_times must not exceed the largest time coordinate "
+                    "when estimating hazard rates."
+                )
+
+            interval_indices = np.searchsorted(time_grid[1:], target_times, side="left")
+            interval_indices = np.clip(interval_indices, 0, time_grid.shape[0] - 2)
+            left_survival = np.clip(survival_curve[interval_indices], eps, None)
+            right_survival = np.clip(survival_curve[interval_indices + 1], eps, None)
+            interval_widths = (
+                time_grid[interval_indices + 1] - time_grid[interval_indices]
+            )
+
+            hazard_mat[i] = -np.log(right_survival / left_survival) / interval_widths
+
+        return hazard_mat
 
     def predict_interval(
         self,
@@ -646,7 +751,16 @@ class SurvivalEvaluator:
             Truncation time. If provided, only pairs whose effective earlier or
             anchor time is strictly before ``tau`` are counted. If None, no
             truncation is applied.
-        :return: (float, float, float)
+
+        Returns
+        -------
+        concordance_index: float
+            The concordance index.
+        num_concordant_pairs: float
+            The number of concordant pairs.
+        num_total_pairs: float
+            The number of total pairs.
+
             The concordance index, the number of concordant pairs, and the number of total pairs.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
@@ -720,6 +834,87 @@ class SurvivalEvaluator:
             The AUC score at the target time point.
         """
         return self.auc(target_time)
+
+    def concordance_time_dependent(
+        self,
+        ties: str = "Risk",
+        method: str = "Antolini",
+        risks: str = "Survival",
+        tau: Optional[Numeric] = None,
+    ) -> tuple[float, float, float]:
+        """
+        Calculate the time-dependent concordance index at each unique event time point.
+
+        Parameters
+        ----------
+        ties: str, default = "Risk"
+            A string indicating the way ties should be handled.
+            Options: "None", "Time", "Risk" (default), or "All"
+            "None" will throw out all ties in true survival time and all ties in predict survival times (risk scores).
+            "Time" includes ties in true survival time but removes ties in predict survival times (risk scores).
+            "Risk" includes ties in predict survival times (risk scores) but not in true survival time.
+            "All" includes all ties.
+            Note the concordance calculation is given by
+            (Concordant Pairs + (Number of Ties/2))/(Concordant Pairs + Discordant Pairs + Number of Ties).
+        method: str, default = "Antolini"
+            A string indicating the method for constructing the pairs of samples.
+            Options are "Antolini" (default), "Naive", "IPCW".
+            "Antolini": comparable pairs are anchored by samples with observed
+            events. If sample i has an observed event at time t_i, it is compared
+            with samples whose observed event/censoring time is greater than t_i.
+            "Naive": alias of "Antolini".
+            "IPCW": Harrell-style comparable pairs weighted by inverse probability
+            of censoring weights from the training data.
+        risks: str, default = "Survival"
+            A string indicating the type of risk scores to be used for concordance calculation.
+            Options are "Survival" (default) and "Hazard".
+            "Survival": the predicted survival probabilities at the anchor's event time are used as risk scores.
+            "Hazard": the predicted hazard rates at the anchor's event time are used as risk scores.
+        tau: float, optional (default=None)
+            Truncation time. If provided, only pairs whose effective earlier or
+            anchor time is strictly before ``tau`` are counted. If None, no
+            truncation is applied.
+
+        Returns
+        -------
+        concordance_index: float
+            The time-dependent concordance index at the target time point.
+        num_concordant_pairs: float
+            The number of concordant pairs.
+        num_total_pairs: float
+            The number of total pairs.
+        """
+        # With fully observed outcomes, Antolini's comparable-pair method is sufficient.
+        method = method.lower()
+        risks = risks.lower()
+
+        if self._NO_CENSOR:
+            method = "antolini"
+
+        if method == "ipcw":
+            self._error_trainset("IPCW time-dependent concordance")
+
+        anchor_times = self.event_times[self.event_indicators == 1]
+        if risks == "survival":
+            risk_scores = -self.predict_multi_probabilities_from_curve(anchor_times)
+        elif risks == "hazard":
+            risk_scores = self.predict_multi_hazards_from_curve(anchor_times)
+        else:
+            error = "Risks must be 'Survival' or 'Hazard', got '{}' instead".format(
+                risks
+            )
+            raise ValueError(error)
+
+        return concordance_time_dependent(
+            risk_scores=risk_scores,
+            event_times=self.event_times,
+            event_indicators=self.event_indicators,
+            train_event_times=self.train_event_times,
+            train_event_indicators=self.train_event_indicators,
+            method=method,
+            ties=ties,
+            tau=tau,
+        )
 
     def brier_score(
         self, target_time: Optional[Numeric] = None, IPCW_weighted: bool = True
@@ -1473,7 +1668,7 @@ class SurvivalEvaluator:
         weightings: Optional[str] = None,
         p: Optional[float] = 0,
         q: Optional[float] = 0,
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Calculate the log-rank test statistic and p-value for the predicted survival curve.
 
@@ -1977,7 +2172,7 @@ class PointEvaluator:
         weightings: Optional[str] = None,
         p: Optional[float] = 0,
         q: Optional[float] = 0,
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Calculate the log-rank test statistic and p-value for the predicted survival curve.
 

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -847,6 +847,12 @@ class SurvivalEvaluator:
         """
         Calculate the time-dependent concordance index.
 
+        Risk scores are evaluated at sample-level observed-event anchor times.
+        If multiple observed events share the same time, that time is represented
+        once per observed event anchor, not once per unique event time. The
+        evaluator preserves the lower-level column contract while skipping risk
+        prediction for anchor columns that cannot enter risk comparisons.
+
         Parameters
         ----------
         ties: str, default = "Risk"

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -867,13 +867,14 @@ class SurvivalEvaluator:
             events. If sample i has an observed event at time t_i, it is compared
             with samples whose observed event/censoring time is greater than t_i.
             "Naive": alias of "Antolini".
-            "IPCW": Harrell-style comparable pairs weighted by inverse probability
+            "IPCW": Antolini-style comparable pairs weighted by inverse probability
             of censoring weights from the training data.
         risks: str, default = "Survival"
             A string indicating the type of risk scores to be used for concordance calculation.
             Options are "Survival" (default) and "Hazard".
-            "Survival": the predicted survival probabilities at the anchor's event time are used as risk scores.
-            "Hazard": the predicted hazard rates at the anchor's event time are used as risk scores.
+            "Survival": predicted survival probabilities at anchor event times are converted to risk scores
+            using -S(t | z).
+            "Hazard": predicted hazard rates at anchor event times are used directly as risk scores.
         tau: float, optional (default=None)
             Truncation time. If provided, only pairs whose effective earlier or
             anchor time is strictly before ``tau`` are counted. If None, no

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -900,15 +900,32 @@ class SurvivalEvaluator:
             self._error_trainset("IPCW time-dependent concordance")
 
         anchor_times = self.event_times[self.event_indicators == 1]
-        if risks == "survival":
-            risk_scores = -self.predict_multi_probabilities_from_curve(anchor_times)
-        elif risks == "hazard":
-            risk_scores = self.predict_multi_hazards_from_curve(anchor_times)
-        else:
+        included_anchor_mask = (
+            np.ones(anchor_times.shape, dtype=bool)
+            if tau is None
+            else anchor_times < tau
+        )
+        included_anchor_times = anchor_times[included_anchor_mask]
+        risk_scores = np.zeros(
+            (self.event_times.shape[0], anchor_times.shape[0]), dtype=float
+        )
+
+        if risks not in {"survival", "hazard"}:
             error = "Risks must be 'Survival' or 'Hazard', got '{}' instead".format(
                 risks
             )
             raise ValueError(error)
+
+        if included_anchor_times.shape[0] > 0:
+            if risks == "survival":
+                included_risk_scores = -self.predict_multi_probabilities_from_curve(
+                    included_anchor_times
+                )
+            else:
+                included_risk_scores = self.predict_multi_hazards_from_curve(
+                    included_anchor_times
+                )
+            risk_scores[:, included_anchor_mask] = included_risk_scores
 
         return concordance_time_dependent(
             risk_scores=risk_scores,

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -188,7 +188,9 @@ class SurvivalEvaluator:
             increase over time.
         """
         if np.any(np.diff(time_coordinates, axis=-1) <= 0):
-            raise ValueError("Each row of time_coordinates must be strictly increasing.")
+            raise ValueError(
+                "Each row of time_coordinates must be strictly increasing."
+            )
         if np.any((pred_survs < 0) | (pred_survs > 1)):
             raise ValueError("Survival probabilities must be between 0 and 1.")
         if np.any(np.diff(pred_survs, axis=-1) > 1e-8):
@@ -359,9 +361,7 @@ class SurvivalEvaluator:
                 target_time,
                 input_name="target_time",
                 allow_scalar=True,
-            )[0] * np.ones(
-                n_samples, dtype=self._time_coordinates.dtype
-            )
+            )[0] * np.ones(n_samples, dtype=self._time_coordinates.dtype)
         elif isinstance(target_time, np.ndarray):
             target_time = validate_time_points(target_time, input_name="target_time")
             if target_time.shape[0] != n_samples:

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -897,18 +897,31 @@ class SurvivalEvaluator:
         if method == "ipcw":
             self._error_trainset("IPCW time-dependent concordance")
 
-        anchor_times = self.event_times[self.event_indicators == 1]
-        # tau truncation excludes anchors at or after tau, so avoid predicting
-        # risks at times that cannot contribute. This matters for hazard risks,
-        # which cannot be extrapolated beyond the prediction grid.
-        included_anchor_mask = (
-            np.ones(anchor_times.shape, dtype=bool)
-            if tau is None
-            else anchor_times < tau
+        event_indicators = self.event_indicators.astype(bool)
+        anchor_times = self.event_times[event_indicators]
+
+        # Only predict risks for anchor columns the concordance counter can
+        # read: event anchors before tau with a later sample or same-time
+        # censored candidate. Final event-only blocks may still add time ties,
+        # but they do not need survival or hazard scores.
+        included_anchor_mask_by_sample = np.zeros(
+            self.event_times.shape[0], dtype=bool
         )
+        for anchor_time in np.unique(anchor_times):
+            if tau is not None and anchor_time >= tau:
+                continue
+            same_time = self.event_times == anchor_time
+            has_later_sample = np.any(self.event_times > anchor_time)
+            has_same_time_censored = np.any(same_time & ~event_indicators)
+            has_candidate = has_later_sample or has_same_time_censored
+            if has_candidate:
+                included_anchor_mask_by_sample[same_time & event_indicators] = True
+
+        included_anchor_mask = included_anchor_mask_by_sample[event_indicators]
         included_anchor_times = anchor_times[included_anchor_mask]
+
         # Keep one column per observed event to preserve the lower-level API
-        # contract; columns for excluded anchors are never read.
+        # contract; columns for anchors without risk comparisons are never read.
         risk_scores = np.zeros(
             (self.event_times.shape[0], anchor_times.shape[0]), dtype=float
         )

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -42,6 +42,7 @@ from SurvivalEVAL.Evaluations.util import (
     predict_rmst,
     quantile_to_survival,
     survival_to_quantile,
+    validate_time_points,
     zero_padding,
 )
 from SurvivalEVAL.Evaluations.util_plots import pp_plot
@@ -353,15 +354,20 @@ class SurvivalEvaluator:
         else:
             raise TypeError("Dimensional error")
 
-        if isinstance(target_time, (float, int)):
-            target_time = target_time * np.ones(
+        if np.isscalar(target_time):
+            target_time = validate_time_points(
+                target_time,
+                input_name="target_time",
+                allow_scalar=True,
+            )[0] * np.ones(
                 n_samples, dtype=self._time_coordinates.dtype
             )
         elif isinstance(target_time, np.ndarray):
-            assert target_time.ndim == 1, "Target time must be a 1D array"
-            assert target_time.shape[0] == n_samples, (
-                "Target time must have the same length as " "the number of samples"
-            )
+            target_time = validate_time_points(target_time, input_name="target_time")
+            if target_time.shape[0] != n_samples:
+                raise ValueError(
+                    "target_time must have the same length as the number of samples."
+                )
         else:
             error = "Target time must be a float, int, or 1D array, got '{}' instead".format(
                 type(target_time)
@@ -409,10 +415,12 @@ class SurvivalEvaluator:
         prob_mat: np.ndarray, shape = (n_samples, n_target_times)
             Predicted survival probabilities at the target time points.
         """
+        target_times = validate_time_points(target_times, input_name="target_times")
+
         if self.ndim_surv == 2 and self.ndim_time == 1:
             n_samples = self._pred_survs.shape[0]
             prob_mat = np.empty(
-                (n_samples, len(target_times)), dtype=self._pred_survs.dtype
+                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
             )
 
             for i, curve in enumerate(self._pred_survs):
@@ -422,7 +430,7 @@ class SurvivalEvaluator:
         elif self.ndim_surv == 1 and self.ndim_time == 2:
             n_samples = self._time_coordinates.shape[0]
             prob_mat = np.empty(
-                (n_samples, len(target_times)), dtype=self._pred_survs.dtype
+                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
             )
 
             for i, times in enumerate(self._time_coordinates):
@@ -432,7 +440,7 @@ class SurvivalEvaluator:
         elif self.ndim_surv == 2 and self.ndim_time == 2:
             n_samples = self._pred_survs.shape[0]
             prob_mat = np.empty(
-                (n_samples, len(target_times)), dtype=self._pred_survs.dtype
+                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
             )
 
             for i in range(n_samples):
@@ -462,11 +470,7 @@ class SurvivalEvaluator:
         hazard_mat: np.ndarray, shape = (n_samples, n_target_times)
             Predicted hazard rates at the target time points.
         """
-        target_times = check_and_convert(target_times).astype(float)
-        if target_times.ndim != 1:
-            raise ValueError("target_times must be a 1-D array.")
-        if np.any(target_times < 0):
-            raise ValueError("target_times must be non-negative.")
+        target_times = validate_time_points(target_times, input_name="target_times")
 
         survival_curves, time_grids = align_curve_and_time_coordinates(
             self._pred_survs,

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -42,6 +42,7 @@ from SurvivalEVAL.Evaluations.util import (
     predict_rmst,
     quantile_to_survival,
     survival_to_quantile,
+    validate_time_point,
     validate_time_points,
     zero_padding,
 )
@@ -357,11 +358,10 @@ class SurvivalEvaluator:
             raise TypeError("Dimensional error")
 
         if np.isscalar(target_time):
-            target_time = validate_time_points(
+            target_time = validate_time_point(
                 target_time,
                 input_name="target_time",
-                allow_scalar=True,
-            )[0] * np.ones(n_samples, dtype=self._time_coordinates.dtype)
+            ) * np.ones(n_samples, dtype=self._time_coordinates.dtype)
         elif isinstance(target_time, np.ndarray):
             target_time = validate_time_points(target_time, input_name="target_time")
             if target_time.shape[0] != n_samples:
@@ -764,8 +764,6 @@ class SurvivalEvaluator:
             The number of concordant pairs.
         num_total_pairs: float
             The number of total pairs.
-
-            The concordance index, the number of concordant pairs, and the number of total pairs.
         """
         # With fully observed outcomes, Harrell's comparable-pair method is sufficient.
         method = method.lower()
@@ -1022,12 +1020,12 @@ class SurvivalEvaluator:
 
     def integrated_brier_score(
         self,
-        num_points: int | None = None,
-        target_times: np.ndarray | None = None,
+        num_points: Optional[int] = None,
+        target_times: Optional[np.ndarray] = None,
         IPCW_weighted: bool = True,
         integration_method: str = "trapz",
         draw_figure: bool = False,
-    ) -> float | tuple[float, tuple[plt.Figure, plt.Axes]]:
+    ) -> Union[float, tuple[float, tuple[plt.Figure, plt.Axes]]]:
         """
         Calculate the integrated Brier score (IBS) from the predicted survival curve.
 
@@ -1336,7 +1334,7 @@ class SurvivalEvaluator:
         binning_strategy: str = "C",
         method: str = "DN",
         return_details: bool = False,
-    ) -> tuple[float, list, list] | tuple[float, dict]:
+    ) -> Union[tuple[float, list, list], tuple[float, dict]]:
         """
         Calculate the one calibration score at a given time point from the predicted survival curve.
         Parameters
@@ -1494,7 +1492,7 @@ class SurvivalEvaluator:
 
     def d_calibration(
         self, num_bins: int = 10, return_details: bool = False
-    ) -> tuple[float, np.ndarray] | tuple[float, dict]:
+    ) -> Union[tuple[float, np.ndarray], tuple[float, dict]]:
         """
         Calculate the D calibration score from the predicted survival curve.
         Parameters
@@ -1590,7 +1588,7 @@ class SurvivalEvaluator:
 
     def ksd_calibration(
         self, return_details: bool = False
-    ) -> tuple[float, float] | tuple[float, dict]:
+    ) -> Union[tuple[float, float], tuple[float, dict]]:
         """
         Calculate the KSD calibration score from the predicted survival curve.
         Parameters
@@ -1658,7 +1656,7 @@ class SurvivalEvaluator:
 
     def km_calibration(
         self, draw_figure: bool = False
-    ) -> float | tuple[float, tuple[plt.Figure, plt.Axes]]:
+    ) -> Union[float, tuple[float, tuple[plt.Figure, plt.Axes]]]:
         """
         Calculate the KM calibration score from the predicted survival curve.
         Parameters
@@ -2368,7 +2366,7 @@ class SingleTimeEvaluator:
         binning_strategy: str = "C",
         method: str = "DN",
         return_details: bool = False,
-    ) -> tuple[float, list, list] | tuple[float, dict]:
+    ) -> Union[tuple[float, list, list], tuple[float, dict]]:
         """
         Calculate the one calibration score at a given time point from the predicted survival curve.
 
@@ -2470,7 +2468,7 @@ class SingleTimeEvaluator:
         knots: int = 3,
         draw_figure: Optional[bool] = True,
         figure_range: Optional[tuple] = None,
-    ) -> dict | tuple[dict, tuple[plt.Figure, plt.Axes]]:
+    ) -> Union[dict, tuple[dict, tuple[plt.Figure, plt.Axes]]]:
         """
         Calculate the integrated one calibration index (ICI) for a given set of predictions and true event times.
 

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -847,7 +847,7 @@ class SurvivalEvaluator:
         tau: Optional[Numeric] = None,
     ) -> tuple[float, float, float]:
         """
-        Calculate the time-dependent concordance index at each unique event time point.
+        Calculate the time-dependent concordance index.
 
         Parameters
         ----------
@@ -883,7 +883,7 @@ class SurvivalEvaluator:
         Returns
         -------
         concordance_index: float
-            The time-dependent concordance index at the target time point.
+            The time-dependent concordance index.
         num_concordant_pairs: float
             The number of concordant pairs.
         num_total_pairs: float
@@ -900,12 +900,17 @@ class SurvivalEvaluator:
             self._error_trainset("IPCW time-dependent concordance")
 
         anchor_times = self.event_times[self.event_indicators == 1]
+        # tau truncation excludes anchors at or after tau, so avoid predicting
+        # risks at times that cannot contribute. This matters for hazard risks,
+        # which cannot be extrapolated beyond the prediction grid.
         included_anchor_mask = (
             np.ones(anchor_times.shape, dtype=bool)
             if tau is None
             else anchor_times < tau
         )
         included_anchor_times = anchor_times[included_anchor_mask]
+        # Keep one column per observed event to preserve the lower-level API
+        # contract; columns for excluded anchors are never read.
         risk_scores = np.zeros(
             (self.event_times.shape[0], anchor_times.shape[0]), dtype=float
         )

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -910,9 +910,7 @@ class SurvivalEvaluator:
         # read: event anchors before tau with a later sample or same-time
         # censored candidate. Final event-only blocks may still add time ties,
         # but they do not need survival or hazard scores.
-        included_anchor_mask_by_sample = np.zeros(
-            self.event_times.shape[0], dtype=bool
-        )
+        included_anchor_mask_by_sample = np.zeros(self.event_times.shape[0], dtype=bool)
         for anchor_time in np.unique(anchor_times):
             if tau is not None and anchor_time >= tau:
                 continue

--- a/SurvivalEVAL/IntervalCenEvaluator.py
+++ b/SurvivalEVAL/IntervalCenEvaluator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from functools import cached_property
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -305,14 +305,14 @@ class IntervalCenEvaluator(SurvivalEvaluator):
 
     def integrated_brier_score(
         self,
-        num_points: int | None = None,
-        target_times: np.ndarray | None = None,
+        num_points: Optional[int] = None,
+        target_times: Optional[np.ndarray] = None,
         method: str = "uncensored",
         x: Optional[np.ndarray] = None,
         x_train: Optional[np.ndarray] = None,
         integration_method: str = "trapz",
         draw_figure: bool = False,
-    ) -> float | tuple[float, tuple[plt.Figure, plt.Axes]]:
+    ) -> Union[float, tuple[float, tuple[plt.Figure, plt.Axes]]]:
         """
         Calculate the Integrated Brier Score (IBS) from the predicted survival curve.
 
@@ -498,8 +498,8 @@ class IntervalCenEvaluator(SurvivalEvaluator):
 
     def crps(
         self,
-        num_points: int | None = None,
-        target_times: np.ndarray | None = None,
+        num_points: Optional[int] = None,
+        target_times: Optional[np.ndarray] = None,
     ) -> float:
         """
         Calculate the Continuous Ranked Probability Score (CRPS) from the predicted survival curve.
@@ -552,7 +552,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
         binning_strategy: str = "C",
         method: str = "Turnbull",
         return_details: bool = False,
-    ) -> tuple[float, list, list] | tuple[float, dict]:
+    ) -> Union[tuple[float, list, list], tuple[float, dict]]:
         """
         Calculate the one calibration score at a given time point from the predicted survival curve.
 
@@ -665,7 +665,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
 
     def d_calibration(
         self, num_bins: int = 10, return_details: bool = False
-    ) -> tuple[float, np.ndarray] | tuple[float, dict]:
+    ) -> Union[tuple[float, np.ndarray], tuple[float, dict]]:
         """
         Calculate the D calibration score from the predicted survival curve.
         Parameters
@@ -762,7 +762,7 @@ class IntervalCenEvaluator(SurvivalEvaluator):
 
     def ksd_calibration(
         self, return_details: bool = False
-    ) -> tuple[float, float] | tuple[float, dict]:
+    ) -> Union[tuple[float, float], tuple[float, dict]]:
         """
         Calculate the K-S-D calibration score from the predicted survival curve.
 

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/CopulaGraphic.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/CopulaGraphic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
+from typing import Union
 
 import numpy as np
 
@@ -109,7 +110,9 @@ class CopulaGraphic:
         self.cumulative_dens = 1 - self.survival_probabilities
         self.probability_dens = np.diff(np.append(self.cumulative_dens, 1))
 
-    def predict(self, prediction_times: int | float | np.ndarray) -> float | np.ndarray:
+    def predict(
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict the survival probabilities at the given prediction times.
         Parameters

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/Fiducial.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/Fiducial.py
@@ -7,7 +7,7 @@ This module provides a fiducial inference method for interval-censored survival 
 """
 
 import warnings
-from typing import Dict, Literal, Optional, Tuple
+from typing import Dict, Literal, Optional
 
 import numpy as np
 import osqp
@@ -23,7 +23,7 @@ _RIDGE = 1e-8  # Ridge regularization for PSD enforcement
 
 def _validate_grid(
     grid_low: float, grid_high: float, ngrid: int
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     """
     Validate and adjust grid bounds to ensure numerical stability.
 
@@ -53,7 +53,7 @@ def _validate_grid(
 
 def _build_qp_matrices(
     ngrid: int, grid: np.ndarray, lam: float = 1.0
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Build the quadratic programming matrices Q (Hessian) for linear interpolation.
 
@@ -137,7 +137,7 @@ def _linear_interpolation_qp(
     rng: np.random.Generator,
     solver: str = "osqp",
     osqp_solver: Optional[object] = None,
-) -> Tuple[np.ndarray, Optional[object]]:
+) -> tuple[np.ndarray, Optional[object]]:
     """
     Solve the quadratic programming problem for linear interpolation.
 
@@ -223,7 +223,7 @@ def _solve_qp_osqp(
     lb: np.ndarray,
     ub: np.ndarray,
     solver: Optional[object] = None,
-) -> Tuple[np.ndarray, object]:
+) -> tuple[np.ndarray, object]:
     """
     Solve QP using OSQP with warm-starting.
 
@@ -325,7 +325,7 @@ def _compute_bounds_fast(
     left: np.ndarray,
     right: np.ndarray,
     query_points: np.ndarray,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Fast computation of fiducial bounds using sorting and searchsorted.
 

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/KaplanMeier.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/KaplanMeier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import InitVar, dataclass, field
+from typing import Union
 
 import numpy as np
 from scipy.integrate import trapezoid
@@ -61,7 +62,9 @@ class KaplanMeier:
         self.cumulative_dens = 1 - self.survival_probabilities
         self.probability_dens = np.diff(np.append(self.cumulative_dens, 1))
 
-    def predict(self, prediction_times: int | float | np.ndarray) -> float | np.ndarray:
+    def predict(
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict the survival probabilities at the given prediction times.
         Parameters

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/NelsonAalen.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/NelsonAalen.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
+from typing import Union
 
 import numpy as np
 
@@ -53,7 +54,9 @@ class NelsonAalen:
             self.cumulative_hazard = np.insert(self.cumulative_hazard, 0, 0.0)
             self.survival_probabilities = np.insert(self.survival_probabilities, 0, 1.0)
 
-    def predict(self, prediction_times: int | float | np.ndarray) -> float | np.ndarray:
+    def predict(
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict the cumulative hazard based on the survival times.
         Parameters
@@ -86,8 +89,8 @@ class NelsonAalen:
         return cumulative_hazard
 
     def predict_survival(
-        self, prediction_times: int | float | np.ndarray
-    ) -> float | np.ndarray:
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict the survival probabilities at the given prediction times.
         Parameters

--- a/SurvivalEVAL/NonparametricEstimator/SingleEvent/Turnbull.py
+++ b/SurvivalEVAL/NonparametricEstimator/SingleEvent/Turnbull.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 from lifelines import KaplanMeierFitter
@@ -200,7 +200,9 @@ class TurnbullEstimator:
 
         return self
 
-    def predict(self, prediction_times: int | float | np.ndarray) -> float | np.ndarray:
+    def predict(
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict survival probabilities at given times using the fitted Turnbull estimator.
         Parameters
@@ -269,7 +271,9 @@ class TurnbullEstimatorLifelines:
         self.cumulative_dens = 1 - self.survival_probabilities
         self.probability_dens = np.diff(np.append(self.cumulative_dens, 1))
 
-    def predict(self, prediction_times: int | float | np.ndarray) -> float | np.ndarray:
+    def predict(
+        self, prediction_times: Union[int, float, np.ndarray]
+    ) -> Union[float, np.ndarray]:
         """
         Predict the survival probabilities at the given prediction times.
         Parameters

--- a/SurvivalEVAL/__init__.py
+++ b/SurvivalEVAL/__init__.py
@@ -7,7 +7,6 @@ from SurvivalEVAL.Evaluations.BrierScore import (
     single_brier_score,
 )
 from SurvivalEVAL.Evaluations.Concordance import (
-    ConcordanceCounts,
     concordance,
     concordance_ic,
 )
@@ -26,6 +25,7 @@ from SurvivalEVAL.Evaluations.SingleTimeCalibration import (
     one_cal_ic,
     one_calibration,
 )
+from SurvivalEVAL.Evaluations.TimeDependentConcordance import concordance_time_dependent
 from SurvivalEVAL.Evaluator import (
     DistributionEvaluator,
     LifelinesEvaluator,
@@ -61,7 +61,7 @@ __all__ = [
     "brier_multiple_points_ic",
     "concordance",
     "concordance_ic",
-    "ConcordanceCounts",
+    "concordance_time_dependent",
     "coverage_ic",
     "d_calibration",
     "km_calibration",

--- a/SurvivalEVAL/__init__.py
+++ b/SurvivalEVAL/__init__.py
@@ -6,10 +6,7 @@ from SurvivalEVAL.Evaluations.BrierScore import (
     brier_score_ic,
     single_brier_score,
 )
-from SurvivalEVAL.Evaluations.Concordance import (
-    concordance,
-    concordance_ic,
-)
+from SurvivalEVAL.Evaluations.Concordance import concordance, concordance_ic
 from SurvivalEVAL.Evaluations.DistributionCalibration import (
     coverage_ic,
     d_cal_ic,

--- a/SurvivalEVAL/version.py
+++ b/SurvivalEVAL/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from SurvivalEVAL import PointEvaluator
+from SurvivalEVAL.Evaluations._concordance_utils import _ConcordanceCounts
 from SurvivalEVAL.Evaluations.Concordance import (
-    ConcordanceCounts,
     _finalize_counts,
     _get_comparable_ic,
     _margin_counts,
@@ -31,7 +31,7 @@ def _brute_harrell_counts(
 ):
     if sample_weights is None:
         sample_weights = np.ones(event_times.shape[0], dtype=float)
-    counts = ConcordanceCounts()
+    counts = _ConcordanceCounts()
 
     for i in range(event_times.shape[0]):
         for j in range(i + 1, event_times.shape[0]):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -88,6 +88,36 @@ def test_prediction_utilities(evaluator_data):
     np.testing.assert_allclose(quantile_intervals, intervals)
 
 
+def test_predict_probability_from_curve_rejects_invalid_target_times(evaluator_data):
+    evaluator = evaluator_data["evaluator"]
+    n_test = evaluator_data["n_test"]
+
+    with pytest.raises(ValueError, match="non-negative"):
+        evaluator.predict_probability_from_curve(-0.1)
+
+    with pytest.raises(ValueError, match="same length"):
+        evaluator.predict_probability_from_curve(np.ones(n_test - 1))
+
+    with pytest.raises(ValueError, match="1-D array"):
+        evaluator.predict_probability_from_curve(np.ones((n_test, 1)))
+
+
+def test_multi_curve_prediction_methods_reject_invalid_target_times(evaluator_data):
+    evaluator = evaluator_data["evaluator"]
+
+    with pytest.raises(ValueError, match="non-negative"):
+        evaluator.predict_multi_probabilities_from_curve(np.array([1.0, -0.1]))
+
+    with pytest.raises(ValueError, match="1-D array"):
+        evaluator.predict_multi_probabilities_from_curve(np.array([[1.0, 2.0]]))
+
+    with pytest.raises(ValueError, match="non-negative"):
+        evaluator.predict_multi_hazards_from_curve(np.array([1.0, -0.1]))
+
+    with pytest.raises(ValueError, match="1-D array"):
+        evaluator.predict_multi_hazards_from_curve(np.array([[1.0, 2.0]]))
+
+
 def test_predict_multi_hazards_from_curve_uses_grid_intervals_not_target_order():
     time_grid = np.array([0.0, 1.0, 3.0])
     pred_survs = np.array(

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -88,6 +88,65 @@ def test_prediction_utilities(evaluator_data):
     np.testing.assert_allclose(quantile_intervals, intervals)
 
 
+def test_predict_multi_hazards_from_curve_uses_grid_intervals_not_target_order():
+    time_grid = np.array([0.0, 1.0, 3.0])
+    pred_survs = np.array(
+        [
+            [1.0, 0.8, 0.4],
+            [1.0, 0.5, 0.25],
+        ]
+    )
+    evaluator = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 1]),
+    )
+
+    target_times = np.array([3.0, 1.0, 1.0, 2.0])
+    hazards = evaluator.predict_multi_hazards_from_curve(target_times)
+
+    expected_first_interval = -np.log(pred_survs[:, 1] / pred_survs[:, 0])
+    expected_second_interval = -np.log(pred_survs[:, 2] / pred_survs[:, 1]) / 2.0
+    expected = np.column_stack(
+        [
+            expected_second_interval,
+            expected_first_interval,
+            expected_first_interval,
+            expected_second_interval,
+        ]
+    )
+
+    np.testing.assert_allclose(hazards, expected)
+
+
+def test_predict_multi_hazards_from_curve_supports_per_sample_time_grids():
+    shared_curve = np.array([1.0, 0.8, 0.4])
+    per_sample_grids = np.array(
+        [
+            [0.0, 1.0, 3.0],
+            [0.0, 2.0, 4.0],
+        ]
+    )
+    evaluator = SurvivalEvaluator(
+        pred_survs=shared_curve,
+        time_coordinates=per_sample_grids,
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 1]),
+    )
+
+    hazards = evaluator.predict_multi_hazards_from_curve(np.array([1.0, 3.0]))
+
+    expected = np.array(
+        [
+            [-np.log(0.8), -np.log(0.4 / 0.8) / 2.0],
+            [-np.log(0.8) / 2.0, -np.log(0.4 / 0.8) / 2.0],
+        ]
+    )
+
+    np.testing.assert_allclose(hazards, expected)
+
+
 def test_survival_evaluator_rejects_prediction_row_count_mismatch():
     with pytest.raises(ValueError, match="prediction rows"):
         SurvivalEvaluator(
@@ -111,6 +170,36 @@ def test_survival_evaluator_rejects_time_coordinate_row_count_mismatch():
             ),
             event_times=np.array([1.0, 2.0]),
             event_indicators=np.array([1, 0]),
+        )
+
+
+def test_survival_evaluator_rejects_nonincreasing_time_coordinates():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        SurvivalEvaluator(
+            pred_survs=np.array([[1.0, 0.8, 0.5]]),
+            time_coordinates=np.array([0.0, 2.0, 1.0]),
+            event_times=np.array([1.0]),
+            event_indicators=np.array([1]),
+        )
+
+
+def test_survival_evaluator_rejects_survival_probabilities_outside_unit_interval():
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        SurvivalEvaluator(
+            pred_survs=np.array([[1.0, 1.2, 0.5]]),
+            time_coordinates=np.array([0.0, 1.0, 2.0]),
+            event_times=np.array([1.0]),
+            event_indicators=np.array([1]),
+        )
+
+
+def test_survival_evaluator_rejects_increasing_survival_probabilities():
+    with pytest.raises(ValueError, match="nonincreasing"):
+        SurvivalEvaluator(
+            pred_survs=np.array([[1.0, 0.7, 0.8]]),
+            time_coordinates=np.array([0.0, 1.0, 2.0]),
+            event_times=np.array([1.0]),
+            event_indicators=np.array([1]),
         )
 
 

--- a/tests/test_time_dependent_concordance.py
+++ b/tests/test_time_dependent_concordance.py
@@ -363,3 +363,22 @@ def test_survival_evaluator_hazard_concordance_tau_skips_excluded_late_anchors()
     )
 
     np.testing.assert_allclose(result, (1.0, 5.0, 5.0))
+
+
+def test_survival_evaluator_hazard_concordance_skips_final_anchor_without_candidates():
+    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
+    hazards = np.array([0.5, 0.3, 0.1])
+    pred_survs = np.exp(-hazards[:, None] * time_grid)
+
+    evaluator = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0, 10.0]),
+        event_indicators=np.array([1, 1, 1]),
+    )
+
+    result = evaluator.concordance_time_dependent(
+        method="Antolini", risks="Hazard"
+    )
+
+    np.testing.assert_allclose(result, (1.0, 3.0, 3.0))

--- a/tests/test_time_dependent_concordance.py
+++ b/tests/test_time_dependent_concordance.py
@@ -377,8 +377,6 @@ def test_survival_evaluator_hazard_concordance_skips_final_anchor_without_candid
         event_indicators=np.array([1, 1, 1]),
     )
 
-    result = evaluator.concordance_time_dependent(
-        method="Antolini", risks="Hazard"
-    )
+    result = evaluator.concordance_time_dependent(method="Antolini", risks="Hazard")
 
     np.testing.assert_allclose(result, (1.0, 3.0, 3.0))

--- a/tests/test_time_dependent_concordance.py
+++ b/tests/test_time_dependent_concordance.py
@@ -342,3 +342,24 @@ def test_survival_evaluator_time_dependent_concordance_end_to_end():
 
     np.testing.assert_allclose(ipcw_survival, (1.0, 2.0, 2.0))
     np.testing.assert_allclose(ipcw_hazard, (1.0, 2.0, 2.0))
+
+
+def test_survival_evaluator_hazard_concordance_tau_skips_excluded_late_anchors():
+    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
+    hazards = np.array([0.5, 0.3, 0.1, 0.05])
+    pred_survs = np.exp(-hazards[:, None] * time_grid)
+
+    evaluator = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0, 10.0, 12.0]),
+        event_indicators=np.array([1, 1, 1, 0]),
+        train_event_times=np.array([1.0, 2.0, 3.0, 4.0]),
+        train_event_indicators=np.array([1, 1, 1, 1]),
+    )
+
+    result = evaluator.concordance_time_dependent(
+        method="IPCW", risks="Hazard", tau=3.0
+    )
+
+    np.testing.assert_allclose(result, (1.0, 5.0, 5.0))

--- a/tests/test_time_dependent_concordance.py
+++ b/tests/test_time_dependent_concordance.py
@@ -1,0 +1,344 @@
+import numpy as np
+import pytest
+
+from SurvivalEVAL import SurvivalEvaluator
+from SurvivalEVAL.Evaluations._concordance_utils import _ConcordanceCounts
+from SurvivalEVAL.Evaluations.TimeDependentConcordance import (
+    _time_dependent_risk_counts,
+    concordance_time_dependent,
+)
+from SurvivalEVAL.NonparametricEstimator.SingleEvent import KaplanMeier
+
+
+def _add_time_dependent_pair(
+    counts,
+    risk_scores,
+    anchor_col_by_sample,
+    anchor,
+    candidate,
+    weight=1.0,
+    tied_tol=1e-8,
+):
+    anchor_col = anchor_col_by_sample[anchor]
+    risk_diff = risk_scores[candidate, anchor_col] - risk_scores[anchor, anchor_col]
+    if abs(risk_diff) <= tied_tol:
+        counts.risk_tie_pairs += weight
+    elif risk_diff < 0:
+        counts.concordant += weight
+    else:
+        counts.discordant += weight
+
+
+def _before_tau(time, tau):
+    return tau is None or time < tau
+
+
+def _brute_time_dependent_counts(
+    event_indicators,
+    event_times,
+    risk_scores,
+    sample_weights=None,
+    anchor_pair_weights=None,
+    tau=None,
+):
+    if sample_weights is None:
+        sample_weights = np.ones(event_times.shape[0], dtype=float)
+
+    event_indicators = event_indicators.astype(bool)
+    anchor_indices = np.flatnonzero(event_indicators)
+    anchor_col_by_sample = np.full(event_times.shape[0], -1, dtype=int)
+    anchor_col_by_sample[anchor_indices] = np.arange(anchor_indices.shape[0])
+
+    counts = _ConcordanceCounts()
+    for i in range(event_times.shape[0]):
+        for j in range(i + 1, event_times.shape[0]):
+            if (
+                event_indicators[i]
+                and event_indicators[j]
+                and event_times[i] == event_times[j]
+                and _before_tau(event_times[i], tau)
+            ):
+                counts.time_tie_pairs += sample_weights[i] * sample_weights[j]
+
+    for i in range(event_times.shape[0]):
+        if not event_indicators[i] or not _before_tau(event_times[i], tau):
+            continue
+
+        for j in range(event_times.shape[0]):
+            if i == j:
+                continue
+            is_later = event_times[j] > event_times[i]
+            is_same_time_censored = (
+                event_times[j] == event_times[i] and not event_indicators[j]
+            )
+            if not (is_later or is_same_time_censored):
+                continue
+
+            if anchor_pair_weights is None:
+                weight = sample_weights[i] * sample_weights[j]
+            else:
+                weight = anchor_pair_weights[i]
+            _add_time_dependent_pair(
+                counts, risk_scores, anchor_col_by_sample, i, j, weight=weight
+            )
+
+    return counts
+
+
+def test_time_dependent_antolini_perfect_and_reversed_rankings():
+    event_times = np.array([1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1])
+    perfect_scores = np.array(
+        [
+            [3.0, 0.0, 0.0],
+            [2.0, 3.0, 0.0],
+            [1.0, 2.0, 0.0],
+        ]
+    )
+    reversed_scores = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [2.0, 1.0, 0.0],
+            [3.0, 2.0, 0.0],
+        ]
+    )
+
+    perfect = concordance_time_dependent(perfect_scores, event_times, event_indicators)
+    reversed_result = concordance_time_dependent(
+        reversed_scores, event_times, event_indicators
+    )
+
+    np.testing.assert_allclose(perfect, (1.0, 3.0, 3.0))
+    np.testing.assert_allclose(reversed_result, (0.0, 0.0, 3.0))
+
+
+def test_time_dependent_antolini_risk_ties_use_existing_tie_policy():
+    risk_scores = np.ones((3, 3))
+    event_times = np.array([1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1])
+
+    with_risk_ties = concordance_time_dependent(
+        risk_scores, event_times, event_indicators, ties="Risk"
+    )
+    without_ties = concordance_time_dependent(
+        risk_scores, event_times, event_indicators, ties="None"
+    )
+
+    np.testing.assert_allclose(with_risk_ties, (0.5, 1.5, 3.0))
+    assert np.isnan(without_ties[0])
+    assert without_ties[1:] == (0.0, 0.0)
+
+
+def test_time_dependent_antolini_time_ties_are_not_comparable_risk_pairs():
+    risk_scores = np.array(
+        [
+            [3.0, 3.0, 0.0],
+            [2.0, 2.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+    event_times = np.array([1.0, 1.0, 2.0])
+    event_indicators = np.array([1, 1, 1])
+
+    risk_only = concordance_time_dependent(
+        risk_scores, event_times, event_indicators, ties="Risk"
+    )
+    with_time_ties = concordance_time_dependent(
+        risk_scores, event_times, event_indicators, ties="Time"
+    )
+
+    np.testing.assert_allclose(risk_only, (1.0, 2.0, 2.0))
+    np.testing.assert_allclose(with_time_ties, (5.0 / 6.0, 2.5, 3.0))
+
+
+def test_private_time_dependent_counts_match_brute_force_for_random_small_inputs():
+    rng = np.random.default_rng(2)
+
+    for n_samples in range(2, 10):
+        for _ in range(50):
+            event_times = rng.integers(1, 6, size=n_samples).astype(float)
+            event_indicators = rng.random(n_samples) < 0.65
+            if not np.any(event_indicators):
+                event_indicators[rng.integers(0, n_samples)] = True
+            risk_scores = rng.integers(
+                -2, 3, size=(n_samples, int(event_indicators.sum()))
+            ).astype(float)
+            sample_weights = rng.uniform(0.25, 2.0, size=n_samples)
+            anchor_pair_weights = rng.uniform(0.25, 2.0, size=n_samples)
+            tau = float(rng.integers(1, 6))
+
+            actual = _time_dependent_risk_counts(
+                risk_scores,
+                event_times,
+                event_indicators,
+                sample_weights=sample_weights,
+                anchor_pair_weights=anchor_pair_weights,
+                tau=tau,
+            )
+            expected = _brute_time_dependent_counts(
+                event_indicators,
+                event_times,
+                risk_scores,
+                sample_weights=sample_weights,
+                anchor_pair_weights=anchor_pair_weights,
+                tau=tau,
+            )
+
+            assert np.isclose(actual.concordant, expected.concordant)
+            assert np.isclose(actual.discordant, expected.discordant)
+            assert np.isclose(actual.risk_tie_pairs, expected.risk_tie_pairs)
+            assert np.isclose(actual.time_tie_pairs, expected.time_tie_pairs)
+
+
+def test_time_dependent_ipcw_uses_squared_anchor_weights():
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    event_indicators = np.array([1, 1, 1, 1])
+    risk_scores = np.array(
+        [
+            [4.0, 0.0, 0.0, 0.0],
+            [3.0, 4.0, 0.0, 0.0],
+            [2.0, 3.0, 4.0, 0.0],
+            [1.0, 2.0, 3.0, 0.0],
+        ]
+    )
+    train_event_times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    train_event_indicators = np.array([1, 0, 1, 0, 1])
+
+    c_index, concordant, total = concordance_time_dependent(
+        risk_scores,
+        event_times,
+        event_indicators,
+        train_event_times=train_event_times,
+        train_event_indicators=train_event_indicators,
+        method="IPCW",
+    )
+
+    censoring_model = KaplanMeier(
+        train_event_times, ~train_event_indicators.astype(bool)
+    )
+    censoring_survival = censoring_model.predict(event_times)
+    anchor_weights = 1 / np.square(censoring_survival)
+    expected_total = 3 * anchor_weights[0] + 2 * anchor_weights[1] + anchor_weights[2]
+
+    assert np.isclose(c_index, 1.0)
+    assert np.isclose(concordant, expected_total)
+    assert np.isclose(total, expected_total)
+
+
+def test_time_dependent_ipcw_tau_excludes_boundary_anchor_and_allows_later_candidates():
+    event_times = np.array([1.0, 2.0, 4.0])
+    event_indicators = np.array([1, 1, 1])
+    risk_scores = np.array(
+        [
+            [3.0, 0.0, 0.0],
+            [2.0, 3.0, 0.0],
+            [1.0, 2.0, 0.0],
+        ]
+    )
+
+    result = concordance_time_dependent(
+        risk_scores,
+        event_times,
+        event_indicators,
+        train_event_times=np.array([1.0, 2.0, 4.0]),
+        train_event_indicators=np.array([1, 1, 1]),
+        method="IPCW",
+        tau=2.0,
+    )
+
+    np.testing.assert_allclose(result, (1.0, 2.0, 2.0))
+
+
+def test_time_dependent_ipcw_ignores_zero_censoring_survival_for_discarded_final_time_ties():
+    event_times = np.array([1.0, 2.0, 2.0])
+    event_indicators = np.array([1, 1, 1])
+    risk_scores = np.array(
+        [
+            [3.0, 0.0, 0.0],
+            [2.0, 3.0, 0.0],
+            [1.0, 2.0, 0.0],
+        ]
+    )
+    kwargs = {
+        "risk_scores": risk_scores,
+        "event_times": event_times,
+        "event_indicators": event_indicators,
+        "train_event_times": np.array([1.0, 2.0]),
+        "train_event_indicators": np.array([1, 0]),
+        "method": "IPCW",
+    }
+
+    default_ties = concordance_time_dependent(**kwargs)
+    no_ties = concordance_time_dependent(**kwargs, ties="None")
+
+    np.testing.assert_allclose(default_ties, (1.0, 2.0, 2.0))
+    np.testing.assert_allclose(no_ties, (1.0, 2.0, 2.0))
+    with pytest.raises(ValueError, match="Censoring survival probability is zero"):
+        concordance_time_dependent(**kwargs, ties="Time")
+    with pytest.raises(ValueError, match="Censoring survival probability is zero"):
+        concordance_time_dependent(**kwargs, ties="All")
+
+
+def test_time_dependent_concordance_validates_inputs():
+    event_times = np.array([1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 1])
+    risk_scores = np.ones((3, 3))
+
+    with pytest.raises(ValueError, match="2D array"):
+        concordance_time_dependent(np.ones(3), event_times, event_indicators)
+    with pytest.raises(ValueError, match="same"):
+        concordance_time_dependent(np.ones((2, 3)), event_times, event_indicators)
+    with pytest.raises(ValueError, match="observed events"):
+        concordance_time_dependent(np.ones((3, 2)), event_times, event_indicators)
+    with pytest.raises(ValueError, match="no observed events"):
+        concordance_time_dependent(np.ones((3, 0)), event_times, np.array([0, 0, 0]))
+    with pytest.raises(ValueError, match="Unsupported method"):
+        concordance_time_dependent(
+            risk_scores, event_times, event_indicators, method="Harrell"
+        )
+    with pytest.raises(ValueError, match="must be provided"):
+        concordance_time_dependent(
+            risk_scores, event_times, event_indicators, method="IPCW"
+        )
+
+
+def test_survival_evaluator_time_dependent_concordance_end_to_end():
+    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
+    hazards = np.array([0.5, 0.2, 0.1])
+    pred_survs = np.exp(-hazards[:, None] * time_grid)
+
+    fully_observed = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 1, 1]),
+    )
+
+    survival_result = fully_observed.concordance_time_dependent(
+        method="Antolini", risks="Survival"
+    )
+    hazard_result = fully_observed.concordance_time_dependent(
+        method="Antolini", risks="Hazard"
+    )
+
+    np.testing.assert_allclose(survival_result, (1.0, 3.0, 3.0))
+    np.testing.assert_allclose(hazard_result, (1.0, 3.0, 3.0))
+
+    censored = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 0, 1]),
+        train_event_times=np.array([1.0, 2.0, 3.0]),
+        train_event_indicators=np.array([1, 1, 1]),
+    )
+
+    ipcw_survival = censored.concordance_time_dependent(
+        method="IPCW", risks="Survival", tau=2.0
+    )
+    ipcw_hazard = censored.concordance_time_dependent(
+        method="IPCW", risks="Hazard", tau=2.0
+    )
+
+    np.testing.assert_allclose(ipcw_survival, (1.0, 2.0, 2.0))
+    np.testing.assert_allclose(ipcw_hazard, (1.0, 2.0, 2.0))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,7 @@ from SurvivalEVAL.Evaluations.util import (
     predict_multi_probs_from_curve,
     predict_prob_from_curve,
     survival_to_quantile,
+    validate_time_point,
     validate_time_points,
     zero_padding,
 )
@@ -362,13 +363,23 @@ def test_predict_prob_from_curve_rejects_negative_time_coordinates():
         )
 
 
-def test_validate_time_points_accepts_scalar_when_allowed():
-    result = validate_time_points(1.5, input_name="target_time", allow_scalar=True)
+def test_validate_time_point_accepts_scalar():
+    result = validate_time_point(1.5, input_name="target_time")
 
-    np.testing.assert_allclose(result, [1.5])
+    assert result == 1.5
 
 
-def test_validate_time_points_rejects_scalar_when_not_allowed():
+def test_validate_time_point_rejects_non_numeric_scalar():
+    with pytest.raises(TypeError, match="target_time must be a numeric scalar"):
+        validate_time_point("1.5", input_name="target_time")
+
+
+def test_validate_time_point_rejects_array_like_input():
+    with pytest.raises(TypeError, match="target_time must be a numeric scalar"):
+        validate_time_point([1.5], input_name="target_time")
+
+
+def test_validate_time_points_rejects_scalar():
     with pytest.raises(ValueError, match="1-D array"):
         validate_time_points(1.5)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,7 @@ from SurvivalEVAL.Evaluations.util import (
     predict_multi_probs_from_curve,
     predict_prob_from_curve,
     survival_to_quantile,
+    validate_time_points,
     zero_padding,
 )
 
@@ -359,6 +360,27 @@ def test_predict_prob_from_curve_rejects_negative_time_coordinates():
             times_coordinate=np.array([-1.0, 1.0, 2.0]),
             target_time=1.0,
         )
+
+
+def test_validate_time_points_accepts_scalar_when_allowed():
+    result = validate_time_points(1.5, input_name="target_time", allow_scalar=True)
+
+    np.testing.assert_allclose(result, [1.5])
+
+
+def test_validate_time_points_rejects_scalar_when_not_allowed():
+    with pytest.raises(ValueError, match="1-D array"):
+        validate_time_points(1.5)
+
+
+def test_validate_time_points_rejects_non_1d_inputs():
+    with pytest.raises(ValueError, match="1-D array"):
+        validate_time_points(np.array([[1.0, 2.0]]))
+
+
+def test_validate_time_points_rejects_negative_values():
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_time_points(np.array([1.0, -0.1]))
 
 
 def test_predict_multi_probs_from_curve_pads_time_grid_starting_after_zero():


### PR DESCRIPTION
# Description

Adds time-dependent concordance support for survival-curve and hazard-rate predictions, updates the evaluator/API surface, and prepares the documentation and version metadata for the next release.

## Updates

1. Add `concordance_time_dependent` and `SurvivalEvaluator.concordance_time_dependent` for Antolini-style survival-curve scoring and IPCW-based time-dependent concordance.
2. Add hazard-rate prediction support for the Gandy-Matcham crossing-hazards concordance use case.
3. Factor shared concordance utilities and add target-time validation coverage.
4. Reconstruct the README metric reference sections with paper-linked metric tables, including Antolini's time-dependent C-index and Gandy-Matcham's time-dependent C-index.
5. Bump the package version and changelog for the 0.8.0 release.

## Fixes

N/A

## Mandatory Checklist

- [x] All new or modified features have corresponding test cases.

- [x] I have run all the tests, using `pytest`, and this is the log I get:

```bash
conda run -n SurvEVAL pytest
183 passed, 18 warnings in 5.45s
```

- [x] All new functions, classes, and modules contain clear docstrings and inline comments.

- [x] All jupyter notebooks are runnable with expected results.

  Not run; no notebook changes.

- [x] I have reformatted and ran `isort .` and `black .` (in this same order) on the codebase.

- [x] I have updated the README and added or edited any new scripts to the integration tests.

- [x] I have ensured sufficient coverage on the newly implemented features.

- [x] I have made sure that both the `requirements.txt` and `pyproject.toml` files are updated according to the newly introduced dependencies.

  No new dependencies introduced.

- [x] Paste the remaining code TODOs using the command `grep -rI --color=auto --exclude-dir={.git,__pycache__,env_folder,.venv,venv,.cache,output,.github,} 'TODO' .` here, and explain them if necessary:

```bash
setup.py:59:TODO:
SurvivalEVAL/Evaluations/MeanError.py:164:        # Error is too small for numerical integration. TODO: consider change the code.
SurvivalEVAL/Evaluations/MeanError.py:466:    # TODO: We need to move this function to util.py since other evaluation metrics might use it.
```

Existing TODOs are unrelated to this PR.