### PR TITLE
Scale right-censored concordance counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 2026-08-23: Version 0.8.2
+
+1. Replace per-anchor enumeration of right-censored concordance pairs with a coordinate-compressed Fenwick tree,
+   reducing the core counting work from quadratic time to `O(n log n)` while retaining `O(n)` storage and avoiding
+   repeated candidate and pair-array allocations.
+2. Preserve Harrell/Naive, Uno/IPCW, and Margin concordance behavior for symmetric and anchor-only weights, strict
+   `tau` truncation, same-time events and censoring, and risk ties within the configured tolerance.
+3. Add randomized brute-force equivalence tests for weighted counts and tie tolerance, plus a 50,000-sample
+   scalability regression test.
+
 ## 2026-08-19: Version 0.8.1
 
 1. Replace repeated multi-time Brier inputs with broadcast views, reuse one-dimensional censoring-survival predictions,

--- a/SurvivalEVAL/Evaluations/Concordance.py
+++ b/SurvivalEVAL/Evaluations/Concordance.py
@@ -8,6 +8,7 @@ from SurvivalEVAL.Evaluations._concordance_utils import (
     _check_has_any_pairs,
     _ConcordanceCounts,
     _count_directed_risk_pairs,
+    _FenwickTree,
     _finalize_counts,
     _is_before_tau,
     _iter_time_blocks,
@@ -204,6 +205,9 @@ def _right_censored_risk_counts(
 ) -> _ConcordanceCounts:
     """Count right-censored comparable pairs for a risk score.
 
+    Candidate risks are maintained in a Fenwick tree, giving ``O(n log n)``
+    time and ``O(n)`` memory without materializing individual pairs.
+
     Parameters
     ----------
     event_indicator: np.ndarray, shape = (n_samples,)
@@ -231,44 +235,65 @@ def _right_censored_risk_counts(
         ``discordant``, and ``risk_tie_pairs`` count comparable pairs;
         ``time_tie_pairs`` counts same-time event pairs.
     """
+    if event_time.shape[0] == 0:
+        return _ConcordanceCounts()
     if sample_weights is None:
         sample_weights = np.ones(event_time.shape[0], dtype=float)
 
+    # Candidate masses are indexed by risk rank. For the symmetric weighted
+    # case a pair receives w_i * w_j. With anchor_pair_weights, every candidate
+    # has unit mass and the anchor supplies the complete pair weight.
+    if anchor_pair_weights is None:
+        candidate_mass = sample_weights
+        anchor_scale = sample_weights
+    else:
+        candidate_mass = np.ones(event_time.shape[0], dtype=float)
+        anchor_scale = anchor_pair_weights
+
+    risk_values, risk_ranks = np.unique(estimate, return_inverse=True)
+    tie_starts = np.searchsorted(risk_values, estimate - tied_tol, side="left")
+    tie_stops = np.searchsorted(risk_values, estimate + tied_tol, side="right")
+    risk_tree = _FenwickTree(risk_values.shape[0])
+    candidate_total = 0.0
+
     counts = _ConcordanceCounts()
-    for block, later_samples in _iter_time_blocks(event_time):
-        if tau is not None and event_time[block[0]] >= tau:
-            break
-
+    order = np.argsort(event_time, kind="stable")
+    end = order.shape[0]
+    while end > 0:
+        start = end - 1
+        block_time = event_time[order[start]]
+        while start > 0 and event_time[order[start - 1]] == block_time:
+            start -= 1
+        block = order[start:end]
+        censored_candidates = block[~event_indicator[block]]
         event_anchors = block[event_indicator[block]]
-        if event_anchors.shape[0] == 0:
-            continue
 
-        # Same-time events are not comparable; same-time censored samples are.
-        counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
-        candidate_indices = np.concatenate(
-            (block[~event_indicator[block]], later_samples)
-        )
-        if candidate_indices.shape[0] == 0:
-            continue
+        # Censoring at the anchor time is comparable, whereas an event at the
+        # same time is not. Add censored samples before querying event anchors.
+        for index in censored_candidates:
+            mass = float(candidate_mass[index])
+            risk_tree.add(int(risk_ranks[index]), mass)
+            candidate_total += mass
 
-        for anchor_index in event_anchors:
-            if anchor_pair_weights is None:
-                pair_weights = (
-                    sample_weights[anchor_index] * sample_weights[candidate_indices]
-                )
-            else:
-                pair_weights = np.full(
-                    candidate_indices.shape[0],
-                    anchor_pair_weights[anchor_index],
-                    dtype=float,
-                )
-            counts += _count_directed_risk_pairs(
-                np.full(candidate_indices.shape[0], anchor_index, dtype=int),
-                candidate_indices,
-                estimate,
-                pair_weights=pair_weights,
-                tied_tol=tied_tol,
+        if (tau is None or block_time < tau) and event_anchors.shape[0] > 0:
+            counts.time_tie_pairs += _same_time_pair_weight(
+                sample_weights[event_anchors]
             )
+            for index in event_anchors:
+                lower_mass = risk_tree.prefix_sum(int(tie_starts[index]))
+                through_ties_mass = risk_tree.prefix_sum(int(tie_stops[index]))
+                tie_mass = through_ties_mass - lower_mass
+                scale = float(anchor_scale[index])
+                counts.concordant += scale * lower_mass
+                counts.risk_tie_pairs += scale * tie_mass
+                counts.discordant += scale * (candidate_total - through_ties_mass)
+
+        # This block becomes strictly later than all subsequent blocks.
+        for index in event_anchors:
+            mass = float(candidate_mass[index])
+            risk_tree.add(int(risk_ranks[index]), mass)
+            candidate_total += mass
+        end = start
 
     return counts
 

--- a/SurvivalEVAL/Evaluations/_concordance_utils.py
+++ b/SurvivalEVAL/Evaluations/_concordance_utils.py
@@ -47,6 +47,31 @@ class _ConcordanceCounts:
         return self
 
 
+class _FenwickTree:
+    """Maintain weighted prefix sums with logarithmic updates and queries."""
+
+    def __init__(self, size: int) -> None:
+        if size <= 0:
+            raise ValueError("Fenwick tree size must be positive.")
+        self._tree = np.zeros(size + 1, dtype=float)
+
+    def add(self, index: int, value: float) -> None:
+        """Add ``value`` to one zero-based position."""
+        position = index + 1
+        while position < self._tree.shape[0]:
+            self._tree[position] += value
+            position += position & -position
+
+    def prefix_sum(self, stop: int) -> float:
+        """Return the sum over zero-based positions in ``[0, stop)``."""
+        total = 0.0
+        position = stop
+        while position > 0:
+            total += self._tree[position]
+            position -= position & -position
+        return total
+
+
 def _finalize_counts(
     counts: _ConcordanceCounts, ties: str
 ) -> tuple[float, float, float]:

--- a/SurvivalEVAL/version.py
+++ b/SurvivalEVAL/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -28,7 +28,13 @@ def _before_tau(time, tau):
 
 
 def _brute_harrell_counts(
-    event_indicators, event_times, risks, sample_weights=None, tau=None
+    event_indicators,
+    event_times,
+    risks,
+    sample_weights=None,
+    anchor_pair_weights=None,
+    tau=None,
+    tied_tol=1e-8,
 ):
     if sample_weights is None:
         sample_weights = np.ones(event_times.shape[0], dtype=float)
@@ -62,7 +68,12 @@ def _brute_harrell_counts(
                     risks,
                     anchor=i,
                     candidate=j,
-                    weight=sample_weights[i] * sample_weights[j],
+                    weight=(
+                        sample_weights[i] * sample_weights[j]
+                        if anchor_pair_weights is None
+                        else anchor_pair_weights[i]
+                    ),
+                    tied_tol=tied_tol,
                 )
 
     return counts
@@ -343,6 +354,84 @@ def test_private_right_censored_risk_counts_match_brute_force_with_tau():
             )
 
             _assert_counts_close(actual, expected)
+
+
+@pytest.mark.parametrize("use_anchor_pair_weights", [False, True])
+def test_private_right_censored_risk_counts_match_weighted_brute_force(
+    use_anchor_pair_weights,
+):
+    rng = np.random.default_rng(2)
+
+    for n_samples in range(2, 12):
+        for _ in range(30):
+            event_times = rng.integers(1, 6, size=n_samples).astype(float)
+            event_indicators = rng.random(n_samples) < 0.65
+            risks = rng.integers(-2, 3, size=n_samples).astype(float)
+            sample_weights = rng.uniform(0.1, 2.0, size=n_samples)
+            anchor_pair_weights = (
+                rng.uniform(0.1, 3.0, size=n_samples)
+                if use_anchor_pair_weights
+                else None
+            )
+            tau = float(rng.integers(1, 7))
+
+            actual = _right_censored_risk_counts(
+                event_indicators,
+                event_times,
+                risks,
+                sample_weights=sample_weights,
+                anchor_pair_weights=anchor_pair_weights,
+                tau=tau,
+            )
+            expected = _brute_harrell_counts(
+                event_indicators,
+                event_times,
+                risks,
+                sample_weights=sample_weights,
+                anchor_pair_weights=anchor_pair_weights,
+                tau=tau,
+            )
+
+            _assert_counts_close(actual, expected)
+
+
+def test_private_right_censored_risk_counts_respects_tie_tolerance():
+    event_times = np.arange(1, 8, dtype=float)
+    event_indicators = np.array([1, 1, 0, 1, 1, 0, 1], dtype=bool)
+    risks = np.array([0.0, 0.5e-8, 1.0e-8, 1.5e-8, -0.5e-8, 1.0, -1.0])
+    sample_weights = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+    tied_tol = 1e-8
+
+    actual = _right_censored_risk_counts(
+        event_indicators,
+        event_times,
+        risks,
+        sample_weights=sample_weights,
+        tied_tol=tied_tol,
+    )
+    expected = _brute_harrell_counts(
+        event_indicators,
+        event_times,
+        risks,
+        sample_weights=sample_weights,
+        tied_tol=tied_tol,
+    )
+
+    _assert_counts_close(actual, expected)
+
+
+def test_private_right_censored_risk_counts_scales_to_large_inputs():
+    n_samples = 50_000
+    event_times = np.arange(n_samples, dtype=float)
+    event_indicators = np.ones(n_samples, dtype=bool)
+    risks = np.arange(n_samples, dtype=float)
+
+    counts = _right_censored_risk_counts(event_indicators, event_times, risks)
+
+    assert counts.concordant == 0.0
+    assert counts.discordant == n_samples * (n_samples - 1) / 2
+    assert counts.risk_tie_pairs == 0.0
+    assert counts.time_tie_pairs == 0.0
 
 
 def test_uno_concordance_uses_censoring_distribution_ipcw():


### PR DESCRIPTION
## Summary

This PR makes right-censored concordance counting practical for large cohorts. It replaces per-anchor pair enumeration with a coordinate-compressed Fenwick tree, reducing the core counting work from quadratic time to `O(n log n)` while using `O(n)` storage and avoiding repeated candidate/pair array allocations.

It also prepares patch release `0.8.2` with an updated package version and changelog entry dated 2026-08-23.

## What changed

- Sweep samples from later to earlier event times while maintaining candidate risk mass in a Fenwick tree.
- Preserve the existing right-censoring semantics: censored samples at an anchor time remain comparable, while events at the same time are tracked as time ties rather than comparable pairs.
- Preserve symmetric sample weighting, Uno/IPCW anchor weighting, Margin concordance, `tau` truncation, and risk-tie tolerance.
- Return empty counts safely for empty internal inputs.
- Bump `SurvivalEVAL.__version__` from `0.8.1` to `0.8.2` and document the release in `CHANGELOG.md`.

## Tests added

- Randomized equivalence checks against a brute-force implementation for symmetric and anchor-only weights.
- Regression coverage for risk ties at the configured tolerance.
- A 50,000-sample scalability test that verifies the expected pair counts without materializing all pairs.

## Validation

- `MPLCONFIGDIR=/private/tmp/survivaleval-matplotlib .venv/bin/pytest -q tests/test_concordance.py`
  - `35 passed in 3.83s`
- `MPLCONFIGDIR=/private/tmp/survivaleval-matplotlib .venv/bin/pytest -q --ignore=tests/test_single_event.py --deselect=tests/test_interval_cen_evaluator.py::test_interval_cen_evaluator_methods`
  - `223 passed, 1 deselected, 19 warnings in 6.70s`
- Built `survivaleval-0.8.2.tar.gz` and `survivaleval-0.8.2-py3-none-any.whl`.
- `twine check` passed for both artifacts.
- Imported `SurvivalEVAL` directly from the built wheel and confirmed version `0.8.2`.

The unmodified full-suite command is currently blocked by a pre-existing test-fixture issue: the repository does not contain `data/breast.csv`. `tests/test_single_event.py` reads a hard-coded copy of that path during collection, and `test_interval_cen_evaluator_methods` loads the same missing fixture. The pycox tests were run successfully with their public METABRIC download available.
