### PR TITLE
Scale time-dependent concordance evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## Unreleased
+
+1. Replace the lower-level time-dependent concordance contract with explicit,
+   strictly increasing `risk_times`, allowing repeated event times to share one
+   risk column and accepting unused extra coordinates.
+2. Build one event-block layout and stream only required per-subject risk
+   prefixes through a configurable 256 MiB compact buffer, without a full
+   sample-by-event-time matrix or per-pair index and weight arrays.
+3. Preserve Antolini, Naive, explicit IPCW, all tie policies, strict `tau`,
+   survival risks, and hazard risks while applying one right-continuous
+   `1 / G(t)^2` IPCW weight per event-time block.
+4. Preserve exact integer-risk comparisons and mixed numeric time matching at
+   float and signed/unsigned representation boundaries, and retain float64
+   interpolation precision for evaluator-generated risks.
+5. Centralize validation for finite real risks, finite non-negative times,
+   binary indicators, IPCW training support, and scalar memory and truncation
+   values; add exhaustive oracle, randomized, evaluator, numeric-boundary, and
+   peak-memory regression tests.
+
 ## 2026-08-23: Version 0.8.2
 
 1. Replace per-anchor enumeration of right-censored concordance pairs with a coordinate-compressed Fenwick tree,

--- a/README.md
+++ b/README.md
@@ -268,7 +268,22 @@ For time-dependent concordance, `risks="Survival"` uses `-S(t | z)` as the risk
 score at each event anchor, while `risks="Hazard"` uses estimated hazard rates
 directly. `method="IPCW"` requires training event times and indicators. `tau`
 keeps event anchors whose observed time is strictly before `tau`; when omitted,
-no truncation is applied.
+no truncation is applied. IPCW event anchors must be within the training-time
+support. The evaluator predicts only the unique event-time risks each subject
+can use and streams subjects through a compact buffer. `working_memory` sets
+that risk buffer's target size in MiB and defaults to 256; one complete compact
+row is the minimum allocation.
+
+The lower-level `concordance_time_dependent` function accepts a `risk_scores`
+matrix shaped `(n_samples, n_risk_times)` and an explicit, strictly increasing
+`risk_times` vector. Repeated event times share one risk-score column, and
+additional unused coordinates are allowed. The grid must contain every event
+time that has a comparable candidate. Risks must be finite; risk, event, and
+training times must be finite and non-negative; and event indicators must be
+binary. The implementation takes `O(n log n + R + P)` time and
+`O(n + Bm + B)` auxiliary space, where `P` is the number of comparable directed
+pairs, `R` is the number of streamed risk cells, `m` is the number of
+contributing event times, and `B` is the memory-budgeted batch size.
 
 ## Interval-Censored Metrics
 

--- a/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
+++ b/SurvivalEVAL/Evaluations/TimeDependentConcordance.py
@@ -1,22 +1,178 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+
 import numpy as np
 
 from SurvivalEVAL.Evaluations._concordance_utils import (
     _check_has_any_pairs,
     _ConcordanceCounts,
-    _count_directed_risk_pairs,
     _finalize_counts,
-    _is_before_tau,
-    _iter_time_blocks,
     _normalize_ties,
-    _same_time_pair_weight,
 )
 from SurvivalEVAL.NonparametricEstimator.SingleEvent import KaplanMeier
+
+_DEFAULT_WORKING_MEMORY = 256.0
+_MEBIBYTE = 1 << 20
+_RiskBatchFiller = Callable[[np.ndarray, np.ndarray, np.ndarray], None]
+
+
+@dataclass(frozen=True)
+class _EventBlockLayout:
+    """The single ordered representation used by all concordance stages."""
+
+    order: np.ndarray
+    event_starts: np.ndarray
+    event_counts: np.ndarray
+    candidate_starts: np.ndarray
+    event_times: np.ndarray
+    risk_block_indices: np.ndarray
+    risk_times: np.ndarray
+    risk_event_starts: np.ndarray
+    risk_event_counts: np.ndarray
+    risk_candidate_starts: np.ndarray
+    subject_risk_prefixes: np.ndarray
+
+
+@dataclass(frozen=True)
+class _PreparedConcordance:
+    """Validated inputs and weights associated with one event-block layout."""
+
+    event_times: np.ndarray
+    event_indicators: np.ndarray
+    method: str
+    ties: str
+    working_bytes: int
+    layout: _EventBlockLayout
+    block_weights: np.ndarray
+
+
+def _as_array(values: object, name: str) -> np.ndarray:
+    """Convert an array-like input without silently accepting malformed data."""
+    try:
+        return np.asarray(values)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must be an array of real numeric values.") from error
+
+
+def _is_real_numeric_array(values: np.ndarray, *, allow_bool: bool = False) -> bool:
+    """Return whether an array has a supported, non-complex numeric dtype."""
+    if allow_bool and np.issubdtype(values.dtype, np.bool_):
+        return True
+    return np.issubdtype(values.dtype, np.integer) or np.issubdtype(
+        values.dtype, np.floating
+    )
+
+
+def _is_real_numeric_scalar(value: object) -> bool:
+    """Return whether a value is a non-Boolean real numeric scalar."""
+    if isinstance(value, np.ndarray):
+        if value.ndim != 0:
+            return False
+        value = value.item()
+    return not isinstance(value, (bool, np.bool_)) and isinstance(
+        value, (int, float, np.integer, np.floating)
+    )
+
+
+def _contains_nonfinite(values: np.ndarray) -> bool:
+    """Check finiteness without allocating an array-shaped Boolean mask."""
+    if values.size == 0 or not np.issubdtype(values.dtype, np.floating):
+        return False
+    return not np.isfinite(values.min()) or not np.isfinite(values.max())
+
+
+def _validate_time_array(
+    values: object,
+    name: str,
+    *,
+    allow_empty: bool,
+) -> np.ndarray:
+    """Validate a one-dimensional array of finite, non-negative times."""
+    array = _as_array(values, name)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D array.")
+    if not allow_empty and array.size == 0:
+        raise ValueError(f"{name} must not be empty.")
+    if not _is_real_numeric_array(array):
+        raise TypeError(f"{name} must contain real numeric values.")
+    if _contains_nonfinite(array):
+        raise ValueError(f"{name} must contain only finite values.")
+    if np.any(array < 0):
+        raise ValueError(f"{name} must contain only non-negative values.")
+    return array
+
+
+def _validate_event_data(
+    event_times: object,
+    event_indicators: object,
+    *,
+    times_name: str = "event_times",
+    indicators_name: str = "event_indicators",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Validate survival outcomes and return Boolean event indicators."""
+    times = _validate_time_array(event_times, times_name, allow_empty=False)
+    indicators = _as_array(event_indicators, indicators_name)
+    if indicators.ndim != 1:
+        raise ValueError(f"{indicators_name} must be a 1-D array.")
+    if times.shape != indicators.shape:
+        raise ValueError(
+            f"{times_name} and {indicators_name} must have the same shape."
+        )
+    if not _is_real_numeric_array(indicators, allow_bool=True):
+        raise TypeError(
+            f"{indicators_name} must contain Boolean or real numeric values."
+        )
+    if not np.issubdtype(indicators.dtype, np.bool_) and not np.all(
+        (indicators == 0) | (indicators == 1)
+    ):
+        raise ValueError(f"{indicators_name} must contain only 0 and 1.")
+    return times, indicators.astype(bool, copy=False)
+
+
+def _validate_tau(tau: object | None) -> object | None:
+    """Validate an optional concordance truncation time without narrowing it."""
+    if tau is None:
+        return None
+    if not _is_real_numeric_scalar(tau):
+        raise TypeError("tau must be a non-negative finite numeric scalar.")
+    scalar = tau.item() if isinstance(tau, np.ndarray) else tau
+    if scalar < 0:
+        raise ValueError("tau must be a non-negative finite numeric scalar.")
+    if isinstance(scalar, (float, np.floating)) and not np.isfinite(scalar):
+        raise ValueError("tau must be a non-negative finite numeric scalar.")
+    return scalar
+
+
+def _validate_working_memory(working_memory: object) -> int:
+    """Validate a MiB risk-buffer target and return its byte count."""
+    if not _is_real_numeric_scalar(working_memory):
+        raise ValueError("working_memory must be a positive finite number of MiB.")
+    scalar = (
+        working_memory.item()
+        if isinstance(working_memory, np.ndarray)
+        else working_memory
+    )
+    try:
+        memory_mib = float(scalar)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError(
+            "working_memory must be a positive finite number of MiB."
+        ) from error
+    if not np.isfinite(memory_mib) or memory_mib <= 0:
+        raise ValueError("working_memory must be a positive finite number of MiB.")
+    memory_bytes = memory_mib * _MEBIBYTE
+    if not np.isfinite(memory_bytes):
+        raise ValueError("working_memory is too large.")
+    return max(1, int(memory_bytes))
 
 
 def _normalize_time_dependent_method(method: str) -> str:
     """Normalize and validate a time-dependent concordance method."""
+    if not isinstance(method, str):
+        raise TypeError("method must be a string.")
     normalized = method.lower()
     if normalized not in {"antolini", "naive", "ipcw"}:
         raise ValueError(
@@ -26,260 +182,549 @@ def _normalize_time_dependent_method(method: str) -> str:
     return normalized
 
 
-def _select_risk_anchors(
+def _numpy_comparison_is_exact(*values: np.ndarray) -> bool:
+    """Return whether NumPy promotion preserves all supplied numeric values."""
+    try:
+        comparison_dtype = np.result_type(*(value.dtype for value in values))
+    except TypeError:
+        return False
+    if np.issubdtype(comparison_dtype, np.integer):
+        return True
+    if not np.issubdtype(comparison_dtype, np.floating):
+        return False
+
+    integer_limit = 1 << (np.finfo(comparison_dtype).nmant + 1)
+    for value in values:
+        if not np.issubdtype(value.dtype, np.integer) or value.size == 0:
+            continue
+        if int(value.min()) < -integer_limit or int(value.max()) > integer_limit:
+            return False
+    return True
+
+
+def _exact_ratio(value: object) -> tuple[int, int]:
+    """Represent an integer or binary floating value exactly."""
+    if isinstance(value, (int, np.integer)):
+        return int(value), 1
+    numerator, denominator = value.as_integer_ratio()
+    return int(numerator), int(denominator)
+
+
+def _searchsorted_exact(
+    sorted_values: np.ndarray,
+    query_values: np.ndarray,
+    *,
+    side: str,
+) -> np.ndarray:
+    """Search sorted coordinates exactly when NumPy promotion would be lossy."""
+    if side not in {"left", "right"}:
+        raise ValueError("side must be 'left' or 'right'.")
+    queries = np.atleast_1d(query_values)
+    if _numpy_comparison_is_exact(sorted_values, queries):
+        return np.searchsorted(sorted_values, queries, side=side)
+
+    positions = np.empty(queries.size, dtype=np.intp)
+    for query_index, query in enumerate(queries):
+        query_numerator, query_denominator = _exact_ratio(query)
+        start = 0
+        stop = sorted_values.size
+        while start < stop:
+            middle = (start + stop) // 2
+            middle_numerator, middle_denominator = _exact_ratio(sorted_values[middle])
+            middle_scaled = middle_numerator * query_denominator
+            query_scaled = query_numerator * middle_denominator
+            move_right = (
+                middle_scaled <= query_scaled
+                if side == "right"
+                else middle_scaled < query_scaled
+            )
+            if move_right:
+                start = middle + 1
+            else:
+                stop = middle
+        positions[query_index] = start
+    return positions.reshape(queries.shape)
+
+
+def _scalar_query(value: object) -> np.ndarray:
+    """Wrap a scalar for exact searching, retaining arbitrarily large integers."""
+    try:
+        return np.asarray([value])
+    except OverflowError:
+        return np.asarray([value], dtype=object)
+
+
+def _build_event_block_layout(
     event_times: np.ndarray,
     event_indicators: np.ndarray,
-    tau: float | None,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return all event anchors and those that require predicted risk scores.
+    tau: object | None,
+) -> _EventBlockLayout:
+    """Sort once and describe all active event blocks and risk prefixes."""
+    order = np.lexsort((~event_indicators, event_times))
+    ordered_times = event_times[order]
+    ordered_indicators = event_indicators[order]
+    block_starts = np.concatenate(
+        (
+            np.array([0], dtype=np.intp),
+            np.flatnonzero(ordered_times[1:] != ordered_times[:-1]) + 1,
+        )
+    )
+    block_event_counts = np.add.reduceat(ordered_indicators, block_starts).astype(
+        np.intp, copy=False
+    )
+    block_times = ordered_times[block_starts]
 
-    Every event before the final observed time has a later candidate. Events
-    at the final time require risks only when that block also contains a
-    censored sample. Final event-only blocks can contribute time ties, but the
-    concordance counter never reads their risk columns.
-    """
-    anchor_times = event_times[event_indicators]
-    if anchor_times.size == 0:
-        return anchor_times, np.zeros(0, dtype=bool)
-
-    final_time = np.max(event_times)
-    included = anchor_times < final_time
-    if np.any((event_times == final_time) & ~event_indicators):
-        included |= anchor_times == final_time
+    tau_stop = block_starts.size
     if tau is not None:
-        included &= anchor_times < tau
-    return anchor_times, included
+        tau_stop = int(
+            _searchsorted_exact(
+                block_times,
+                _scalar_query(tau),
+                side="left",
+            )[0]
+        )
+    active = np.flatnonzero(block_event_counts[:tau_stop] > 0)
+    event_starts = block_starts[active]
+    event_counts = block_event_counts[active]
+    candidate_starts = event_starts + event_counts
+    active_event_times = block_times[active]
+
+    risk_block_indices = np.flatnonzero(candidate_starts < order.size)
+    risk_event_starts = event_starts[risk_block_indices]
+    risk_event_counts = event_counts[risk_block_indices]
+    risk_candidate_starts = candidate_starts[risk_block_indices]
+    risk_times = active_event_times[risk_block_indices]
+
+    subject_risk_prefixes = np.zeros(order.size, dtype=np.intp)
+    if risk_block_indices.size:
+        subject_risk_prefixes[risk_candidate_starts] = 1
+        np.cumsum(subject_risk_prefixes, out=subject_risk_prefixes)
+        for risk_column, (event_start, event_count) in enumerate(
+            zip(risk_event_starts, risk_event_counts)
+        ):
+            subject_risk_prefixes[event_start : event_start + event_count] = (
+                risk_column + 1
+            )
+
+    return _EventBlockLayout(
+        order=order,
+        event_starts=event_starts,
+        event_counts=event_counts,
+        candidate_starts=candidate_starts,
+        event_times=active_event_times,
+        risk_block_indices=risk_block_indices,
+        risk_times=risk_times,
+        risk_event_starts=risk_event_starts,
+        risk_event_counts=risk_event_counts,
+        risk_candidate_starts=risk_candidate_starts,
+        subject_risk_prefixes=subject_risk_prefixes,
+    )
+
+
+def _ipcw_block_weights(
+    layout: _EventBlockLayout,
+    train_event_times: object | None,
+    train_event_indicators: object | None,
+    ties: str,
+) -> np.ndarray:
+    """Calculate one right-continuous IPCW weight per active event block."""
+    if train_event_times is None or train_event_indicators is None:
+        raise ValueError(
+            "train_event_times and train_event_indicators must be provided "
+            "for IPCW method."
+        )
+    train_times, train_indicators = _validate_event_data(
+        train_event_times,
+        train_event_indicators,
+        times_name="train_event_times",
+        indicators_name="train_event_indicators",
+    )
+
+    weights = np.ones(layout.event_times.size, dtype=float)
+    needs_weight = np.zeros(layout.event_times.size, dtype=bool)
+    needs_weight[layout.risk_block_indices] = True
+    if ties in {"time", "all"}:
+        needs_weight |= layout.event_counts > 1
+    contributing_times = layout.event_times[needs_weight]
+    if contributing_times.size == 0:
+        return weights
+
+    support = np.asarray([train_times.max()])
+    beyond_support = _searchsorted_exact(
+        support,
+        contributing_times,
+        side="left",
+    )
+    if np.any(beyond_support == support.size):
+        raise ValueError(
+            "Contributing event times must not exceed the largest training "
+            "time; choose a smaller tau."
+        )
+
+    censoring_model = KaplanMeier(train_times, ~train_indicators)
+    survival_indices = (
+        _searchsorted_exact(
+            censoring_model.survival_times,
+            contributing_times,
+            side="right",
+        )
+        - 1
+    )
+    censoring_survival = censoring_model.survival_probabilities[survival_indices]
+    if np.any(censoring_survival <= 0):
+        raise ValueError(
+            "Censoring survival probability is zero for at least one observed "
+            "event; choose a smaller tau."
+        )
+    weights[needs_weight] = 1.0 / np.square(censoring_survival)
+    return weights
+
+
+def _prepare_concordance(
+    event_times: object,
+    event_indicators: object,
+    train_event_times: object | None,
+    train_event_indicators: object | None,
+    method: str,
+    ties: str,
+    tau: object | None,
+    working_memory: object,
+) -> _PreparedConcordance:
+    """Validate shared inputs and construct the sole event-block layout."""
+    normalized_method = _normalize_time_dependent_method(method)
+    if not isinstance(ties, str):
+        raise TypeError("ties must be a string.")
+    normalized_ties = _normalize_ties(ties)
+    validated_tau = _validate_tau(tau)
+    working_bytes = _validate_working_memory(working_memory)
+    times, indicators = _validate_event_data(event_times, event_indicators)
+    if not np.any(indicators):
+        raise ValueError(
+            "Data has no observed events, cannot estimate time-dependent "
+            "concordance index."
+        )
+
+    layout = _build_event_block_layout(times, indicators, validated_tau)
+    if normalized_method == "ipcw":
+        block_weights = _ipcw_block_weights(
+            layout,
+            train_event_times,
+            train_event_indicators,
+            normalized_ties,
+        )
+    else:
+        block_weights = np.ones(layout.event_times.size, dtype=float)
+
+    return _PreparedConcordance(
+        event_times=times,
+        event_indicators=indicators,
+        method=normalized_method,
+        ties=normalized_ties,
+        working_bytes=working_bytes,
+        layout=layout,
+        block_weights=block_weights,
+    )
+
+
+def _required_risk_columns(
+    risk_times: np.ndarray,
+    required_times: np.ndarray,
+) -> np.ndarray:
+    """Locate every required event time on an explicit risk-time grid."""
+    left = _searchsorted_exact(risk_times, required_times, side="left")
+    right = _searchsorted_exact(risk_times, required_times, side="right")
+    matched = right > left
+    if not np.all(matched):
+        missing = required_times[~matched]
+        raise ValueError(
+            "risk_times must include every contributing event time; missing "
+            f"{missing.tolist()}."
+        )
+    return left
+
+
+def _fill_matrix_risk_batch(
+    risk_scores: np.ndarray,
+    required_columns: np.ndarray,
+    sample_indices: np.ndarray,
+    risk_prefixes: np.ndarray,
+    output: np.ndarray,
+) -> None:
+    """Copy compact matrix risks without a second batch-sized allocation."""
+    for output_column, source_column in enumerate(required_columns[: output.shape[1]]):
+        first_row = int(np.searchsorted(risk_prefixes, output_column, side="right"))
+        np.take(
+            risk_scores[:, source_column],
+            sample_indices[first_row:],
+            out=output[first_row:, output_column],
+            mode="clip",
+        )
+
+
+def _validate_matrix_risk_source(
+    risk_scores: object,
+    risk_times: object,
+    prepared: _PreparedConcordance,
+) -> tuple[np.dtype, _RiskBatchFiller]:
+    """Validate matrix-specific inputs and return a compact batch filler."""
+    scores = _as_array(risk_scores, "risk_scores")
+    coordinates = _validate_time_array(risk_times, "risk_times", allow_empty=True)
+    if scores.ndim != 2:
+        raise ValueError(
+            "risk_scores should be a 2D array of shape "
+            f"(n_samples, n_risk_times), but got shape {scores.shape}."
+        )
+    if scores.shape[0] != prepared.event_times.size:
+        raise ValueError(
+            "The lengths of risk_scores, event_times, and event_indicators "
+            "must be the same."
+        )
+    if scores.shape[1] != coordinates.size:
+        raise ValueError(
+            "The number of columns in risk_scores must match the length of risk_times."
+        )
+    if not _is_real_numeric_array(scores):
+        raise TypeError("risk_scores must contain real numeric values.")
+    if _contains_nonfinite(scores):
+        raise ValueError("risk_scores must contain only finite values.")
+    if coordinates.size > 1 and np.any(coordinates[1:] <= coordinates[:-1]):
+        raise ValueError("risk_times must be strictly increasing and unique.")
+
+    required_columns = _required_risk_columns(
+        coordinates,
+        prepared.layout.risk_times,
+    )
+    return scores.dtype, partial(
+        _fill_matrix_risk_batch,
+        scores,
+        required_columns,
+    )
+
+
+def _validate_tied_tolerance(tied_tol: object) -> float:
+    """Validate the non-negative finite risk-tie tolerance."""
+    if not _is_real_numeric_scalar(tied_tol):
+        raise ValueError("tied_tol must be a non-negative finite number.")
+    try:
+        tolerance = float(tied_tol)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError("tied_tol must be a non-negative finite number.") from error
+    if not np.isfinite(tolerance) or tolerance < 0:
+        raise ValueError("tied_tol must be a non-negative finite number.")
+    return tolerance
+
+
+def _count_streamed_risks(
+    prepared: _PreparedConcordance,
+    risk_dtype: np.dtype,
+    fill_risk_batch: _RiskBatchFiller,
+    *,
+    tied_tol: object = 1e-8,
+) -> _ConcordanceCounts:
+    """Count each comparable directed pair once using a bounded risk buffer."""
+    tolerance = _validate_tied_tolerance(tied_tol)
+    layout = prepared.layout
+    tie_pair_counts = 0.5 * layout.event_counts * (layout.event_counts - 1)
+    counts = _ConcordanceCounts(
+        time_tie_pairs=float(np.dot(tie_pair_counts, prepared.block_weights))
+    )
+    n_risk_times = layout.risk_times.size
+    if n_risk_times == 0:
+        return counts
+
+    dtype = np.dtype(risk_dtype)
+    bytes_per_row = max(1, n_risk_times * dtype.itemsize)
+    batch_size = min(
+        layout.order.size,
+        max(1, prepared.working_bytes // bytes_per_row),
+    )
+    risk_buffer = np.empty((batch_size, n_risk_times), dtype=dtype, order="F")
+    selected = np.empty(batch_size, dtype=bool)
+
+    integer_risks = np.issubdtype(dtype, np.integer)
+    if integer_risks:
+        integer_limits = np.iinfo(dtype)
+        integer_tolerance = int(np.floor(tolerance))
+        comparison_buffer = None
+    else:
+        comparison_dtype = np.result_type(dtype, np.float64)
+        comparison_buffer = np.empty(batch_size, dtype=comparison_dtype)
+
+    anchor_offsets = np.concatenate(
+        (
+            np.array([0], dtype=np.intp),
+            np.cumsum(layout.risk_event_counts, dtype=np.intp),
+        )
+    )
+    anchor_risks = np.empty(anchor_offsets[-1], dtype=dtype)
+    next_anchor_block = 0
+
+    for batch_start in range(0, layout.order.size, batch_size):
+        batch_stop = min(batch_start + batch_size, layout.order.size)
+        current_size = batch_stop - batch_start
+        prefixes = layout.subject_risk_prefixes[batch_start:batch_stop]
+        active_columns = int(prefixes[-1])
+        if active_columns == 0:
+            continue
+
+        current_risks = risk_buffer[:current_size, :active_columns]
+        fill_risk_batch(
+            layout.order[batch_start:batch_stop],
+            prefixes,
+            current_risks,
+        )
+
+        while (
+            next_anchor_block < n_risk_times
+            and layout.risk_event_starts[next_anchor_block] < batch_stop
+        ):
+            event_start = int(layout.risk_event_starts[next_anchor_block])
+            event_stop = event_start + int(layout.risk_event_counts[next_anchor_block])
+            overlap_start = max(event_start, batch_start)
+            overlap_stop = min(event_stop, batch_stop)
+            if overlap_start < overlap_stop:
+                destination_start = int(anchor_offsets[next_anchor_block]) + (
+                    overlap_start - event_start
+                )
+                destination_stop = destination_start + overlap_stop - overlap_start
+                anchor_risks[destination_start:destination_stop] = current_risks[
+                    overlap_start - batch_start : overlap_stop - batch_start,
+                    next_anchor_block,
+                ]
+            if event_stop <= batch_stop:
+                next_anchor_block += 1
+            else:
+                break
+
+        active_blocks = int(
+            np.searchsorted(layout.risk_candidate_starts, batch_stop, side="left")
+        )
+        for risk_column in range(active_blocks):
+            first_candidate = max(
+                int(layout.risk_candidate_starts[risk_column]),
+                batch_start,
+            )
+            candidate_risks = current_risks[
+                first_candidate - batch_start :, risk_column
+            ]
+            n_candidates = candidate_risks.size
+            block_selected = selected[:n_candidates]
+            block_weight = float(
+                prepared.block_weights[layout.risk_block_indices[risk_column]]
+            )
+            anchors = anchor_risks[
+                anchor_offsets[risk_column] : anchor_offsets[risk_column + 1]
+            ]
+
+            for anchor_risk_value in anchors:
+                if integer_risks:
+                    anchor_risk = int(anchor_risk_value)
+                    lower_tie_bound = dtype.type(
+                        max(integer_limits.min, anchor_risk - integer_tolerance)
+                    )
+                    upper_tie_bound = dtype.type(
+                        min(integer_limits.max, anchor_risk + integer_tolerance)
+                    )
+                    np.less(candidate_risks, lower_tie_bound, out=block_selected)
+                    concordant = float(np.count_nonzero(block_selected))
+                    np.less_equal(
+                        candidate_risks,
+                        upper_tie_bound,
+                        out=block_selected,
+                    )
+                else:
+                    difference = comparison_buffer[:n_candidates]
+                    with np.errstate(over="ignore", invalid="ignore"):
+                        np.subtract(candidate_risks, anchor_risk_value, out=difference)
+                    np.less(difference, -tolerance, out=block_selected)
+                    concordant = float(np.count_nonzero(block_selected))
+                    np.less_equal(difference, tolerance, out=block_selected)
+
+                through_ties = float(np.count_nonzero(block_selected))
+                counts.concordant += block_weight * concordant
+                counts.risk_tie_pairs += block_weight * (through_ties - concordant)
+                counts.discordant += block_weight * (n_candidates - through_ties)
+
+    return counts
+
+
+def _concordance_from_risk_batches(
+    prepared: _PreparedConcordance,
+    risk_dtype: np.dtype,
+    fill_risk_batch: _RiskBatchFiller,
+) -> tuple[float, float, float]:
+    """Count and finalize concordance for an already prepared risk source."""
+    counts = _count_streamed_risks(prepared, risk_dtype, fill_risk_batch)
+    _check_has_any_pairs(counts)
+    return _finalize_counts(counts, prepared.ties)
 
 
 def concordance_time_dependent(
-    risk_scores: np.ndarray,
-    event_times: np.ndarray,
-    event_indicators: np.ndarray,
-    train_event_times: np.ndarray | None = None,
-    train_event_indicators: np.ndarray | None = None,
+    risk_scores: object,
+    risk_times: object,
+    event_times: object,
+    event_indicators: object,
+    train_event_times: object | None = None,
+    train_event_indicators: object | None = None,
     method: str = "Antolini",
     ties: str = "Risk",
-    tau: float | None = None,
+    tau: object | None = None,
+    working_memory: object = _DEFAULT_WORKING_MEMORY,
 ) -> tuple[float, float, float]:
-    """
-    Calculate the time-dependent concordance index between the predicted risk scores and the true survival times.
+    """Calculate exact, memory-bounded time-dependent concordance.
 
     Parameters
     ----------
-    risk_scores: np.ndarray, shape = (n_samples, n_anchor_times)
-        The predicted risk scores for each sample at each anchor time.
-        The risk scores should be ordered such that higher scores indicate higher risk
-        (i.e., lower survival probability or higher hazard score).
-        ``risk_scores[i, k]`` is the risk score for test sample ``i``
-        evaluated at the kth observed-event anchor time. The kth anchor time
-        corresponds to ``event_times[np.flatnonzero(event_indicators)[k]]``.
-        Anchor times are sample-level observed events, not unique event times.
-        If multiple observed events share the same time, ``risk_scores`` must
-        include one column for each of those samples in observed-event sample
-        order.
-    event_times: np.ndarray, shape = (n_samples,)
-        The true survival times.
-    event_indicators: np.ndarray, shape = (n_samples,)
-        Binary event indicators: 1 denotes an observed event and 0 denotes a
-        censored observation.
-    train_event_times: np.ndarray, shape = (n_train_samples,), optional
-        The true survival times of the training set. Required for "IPCW".
-    train_event_indicators: np.ndarray, shape = (n_train_samples,), optional
-        Binary training-set event indicators: 1 denotes an observed event and
-        0 denotes a censored observation. Required for "IPCW".
-    method: str, optional (default="Antolini")
-        A string indicating the method for constructing the pairs of samples.
-        Options are "Antolini" (default), "Naive", or "IPCW".
-        "Antolini": comparable pairs are anchored by samples with observed
-        events. If sample i has an observed event at time t_i, it is compared
-        with samples whose observed event/censoring time is greater than t_i.
-        "Naive": alias of "Antolini".
-        "IPCW": Antolini-style comparable pairs weighted by inverse probability
-        of censoring weights from the training data.
-    ties: str, optional (default="Risk")
-        A string indicating the way ties should be handled.
-        Options: "None", "Time", "Risk" (default), or "All"
-    tau: float, optional
-        Truncation time. If provided, only event anchors whose observed time is
-        strictly before ``tau`` are counted. If None, no truncation is applied.
+    risk_scores : array-like, shape = (n_samples, n_risk_times)
+        Finite risk scores at ``risk_times``. Higher values indicate greater
+        event risk.
+    risk_times : array-like, shape = (n_risk_times,)
+        Finite, non-negative, strictly increasing unique coordinates. Every
+        event time with a comparable candidate must be present. Repeated event
+        times share one column; unused extra coordinates are allowed.
+    event_times : array-like, shape = (n_samples,)
+        Finite, non-negative observed event or censoring times.
+    event_indicators : array-like, shape = (n_samples,)
+        Binary indicators where 1 denotes an observed event.
+    train_event_times : array-like, optional
+        Training event or censoring times, required for ``"IPCW"``.
+    train_event_indicators : array-like, optional
+        Binary training indicators, required for ``"IPCW"``.
+    method : str, default="Antolini"
+        One of ``"Antolini"``, ``"Naive"``, or ``"IPCW"``.
+    ties : str, default="Risk"
+        One of ``"None"``, ``"Time"``, ``"Risk"``, or ``"All"``.
+    tau : real scalar, optional
+        Count only event anchors strictly before this non-negative finite time.
+    working_memory : real scalar, default=256
+        Target MiB for the compact risk buffer. If one complete compact row is
+        larger than the target, one row is still allocated.
 
     Returns
     -------
-    c_index: float
-        The concordance index.
-    num_concordant_pairs: float
-        The number of concordant pairs.
-    num_total_pairs: float
-        The number of total pairs.
+    tuple[float, float, float]
+        Concordance index, concordant-pair mass, and total-pair mass.
+
+    Notes
+    -----
+    The calculation takes ``O(n log n + R + P)`` time and
+    ``O(n + Bm + B)`` auxiliary space. ``P`` is the number of comparable
+    directed pairs, ``R`` the number of streamed risk cells, ``m`` the number
+    of contributing event times, and ``B`` the memory-budgeted batch size.
     """
-    event_indicators = event_indicators.astype(bool, copy=False)
-
-    if risk_scores.ndim != 2:
-        raise ValueError(
-            f"risk_scores should be a 2D array of shape (n_samples, n_anchor_times), but got shape {risk_scores.shape}."
-        )
-    if event_times.ndim != 1 or event_indicators.ndim != 1:
-        raise ValueError("event_times and event_indicators must be 1-D arrays.")
-
-    # check if the predicted risk scores has the dimension of (n_samples, n_anchor_times)
-    n_samples, n_anchor_times = risk_scores.shape
-    if not (n_samples == event_times.shape[0] == event_indicators.shape[0]):
-        raise ValueError(
-            "The lengths of risk_scores, event_times, and event_indicators must be the same."
-        )
-
-    n_observed_events = int(event_indicators.sum())
-    if n_observed_events == 0:
-        raise ValueError(
-            "Data has no observed events, cannot estimate time-dependent concordance index."
-        )
-    if n_anchor_times != n_observed_events:
-        raise ValueError(
-            "The number of anchor times (columns in risk_scores) must match the number of observed events."
-        )
-
-    method = _normalize_time_dependent_method(method)
-    ties = _normalize_ties(ties)
-
-    if method == "antolini" or method == "naive":
-        sample_weights = None
-        anchor_pair_weights = None
-    elif method == "ipcw":
-        if train_event_times is None or train_event_indicators is None:
-            raise ValueError(
-                "train_event_times and train_event_indicators must be provided for IPCW method."
-            )
-        train_event_indicators = train_event_indicators.astype(bool, copy=False)
-
-        censoring_model = KaplanMeier(train_event_times, ~train_event_indicators)
-        censoring_survival = censoring_model.predict(event_times)
-        observed_anchors = event_indicators & _is_before_tau(event_times, tau)
-
-        # IPCW only needs positive censoring survival for event anchors whose
-        # weights can affect the selected concordance result. Every non-final
-        # event-time block has later samples as candidates. In the final block,
-        # event anchors still contribute through same-time censored candidates;
-        # event-event time ties contribute only when the requested tie policy
-        # keeps time ties. Otherwise final events have no effect on the returned
-        # index, so exclude them from the zero-survival check and weight
-        # assignment.
-        final_time = np.max(event_times)
-        final_block = event_times == final_time
-        final_events = final_block & event_indicators
-        final_event_count = np.count_nonzero(final_events)
-        final_has_censored_candidate = np.any(final_block & ~event_indicators)
-        final_time_ties_counted = ties in {"time", "all"}
-        final_events_contribute = final_has_censored_candidate or (
-            final_time_ties_counted and final_event_count > 1
-        )
-        if not final_events_contribute:
-            observed_anchors[final_events] = False
-
-        if np.any(censoring_survival[observed_anchors] <= 0):
-            raise ValueError(
-                "Censoring survival probability is zero for at least one observed event; "
-                "choose a smaller tau."
-            )
-
-        sample_weights = np.zeros_like(event_times, dtype=float)
-        sample_weights[observed_anchors] = 1 / censoring_survival[observed_anchors]
-
-        anchor_pair_weights = np.zeros_like(event_times, dtype=float)
-        anchor_pair_weights[observed_anchors] = 1 / np.square(
-            censoring_survival[observed_anchors]
-        )
-    counts = _time_dependent_risk_counts(
-        risk_scores=risk_scores,
-        event_times=event_times,
-        event_indicators=event_indicators,
-        sample_weights=sample_weights,
-        anchor_pair_weights=anchor_pair_weights,
-        tau=tau,
+    prepared = _prepare_concordance(
+        event_times,
+        event_indicators,
+        train_event_times,
+        train_event_indicators,
+        method,
+        ties,
+        tau,
+        working_memory,
     )
-
-    _check_has_any_pairs(counts)
-    return _finalize_counts(counts, ties)
-
-
-def _time_dependent_risk_counts(
-    risk_scores: np.ndarray,
-    event_times: np.ndarray,
-    event_indicators: np.ndarray,
-    sample_weights: np.ndarray | None = None,
-    anchor_pair_weights: np.ndarray | None = None,
-    tau: float | None = None,
-    tied_tol: float = 1e-8,
-) -> _ConcordanceCounts:
-    """Count Antolini-style time-dependent concordance pairs.
-
-    Parameters
-    ----------
-    risk_scores: np.ndarray, shape = (n_samples, n_observed_events)
-        Risk scores evaluated at observed-event anchor times. Higher scores
-        indicate higher event risk.
-    event_times: np.ndarray, shape = (n_samples,)
-        Observed event or censoring times.
-    event_indicators: np.ndarray, shape = (n_samples,)
-        Boolean event indicators, where True denotes an observed event.
-    sample_weights: np.ndarray, shape = (n_samples,), optional
-        Optional symmetric sample weights used for same-time event ties and,
-        unless ``anchor_pair_weights`` is provided, comparable pair weights.
-    anchor_pair_weights: np.ndarray, shape = (n_samples,), optional
-        Optional per-anchor pair weights. If provided, every comparable pair
-        anchored by sample ``i`` receives ``anchor_pair_weights[i]``.
-    tau: float, optional (default=None)
-        Truncation time. If provided, only event anchors whose observed time is
-        strictly before ``tau`` are counted. If None, no truncation is applied.
-    tied_tol: float, optional (default=1e-8)
-        Absolute tolerance for risk-score ties.
-
-    Returns
-    -------
-    _ConcordanceCounts
-        Raw concordance counts before tie-mode finalization.
-    """
-    if sample_weights is None:
-        sample_weights = np.ones(event_times.shape[0], dtype=float)
-
-    anchor_indices = np.flatnonzero(event_indicators)
-    anchor_col_by_sample = np.full(event_times.shape[0], -1, dtype=int)
-    anchor_col_by_sample[anchor_indices] = np.arange(anchor_indices.shape[0])
-
-    counts = _ConcordanceCounts()
-    for block, later_samples in _iter_time_blocks(event_times):
-        if tau is not None and event_times[block[0]] >= tau:
-            break
-
-        event_anchors = block[event_indicators[block]]
-        if event_anchors.shape[0] == 0:
-            continue
-
-        counts.time_tie_pairs += _same_time_pair_weight(sample_weights[event_anchors])
-
-        candidate_indices = np.concatenate(
-            (block[~event_indicators[block]], later_samples)
-        )
-        if candidate_indices.shape[0] == 0:
-            continue
-
-        for anchor_index in event_anchors:
-            anchor_col = anchor_col_by_sample[anchor_index]
-            if anchor_pair_weights is None:
-                pair_weights = (
-                    sample_weights[anchor_index] * sample_weights[candidate_indices]
-                )
-            else:
-                pair_weights = np.full(
-                    candidate_indices.shape[0],
-                    anchor_pair_weights[anchor_index],
-                    dtype=float,
-                )
-            counts += _count_directed_risk_pairs(
-                np.full(candidate_indices.shape[0], anchor_index, dtype=int),
-                candidate_indices,
-                risk_scores[:, anchor_col],
-                pair_weights=pair_weights,
-                tied_tol=tied_tol,
-            )
-
-    return counts
+    risk_dtype, filler = _validate_matrix_risk_source(
+        risk_scores,
+        risk_times,
+        prepared,
+    )
+    return _concordance_from_risk_batches(prepared, risk_dtype, filler)

--- a/SurvivalEVAL/Evaluator.py
+++ b/SurvivalEVAL/Evaluator.py
@@ -11,7 +11,6 @@ import pandas as pd
 from lifelines.statistics import logrank_test
 from scipy.integrate import simpson, trapezoid
 
-from SurvivalEVAL.Evaluations._concordance_utils import _normalize_ties
 from SurvivalEVAL.Evaluations.AreaUnderPRCurve import auprc_right_censor
 from SurvivalEVAL.Evaluations.AreaUnderROCurve import auc
 from SurvivalEVAL.Evaluations.BrierScore import (
@@ -32,9 +31,8 @@ from SurvivalEVAL.Evaluations.SingleTimeCalibration import (
     one_calibration,
 )
 from SurvivalEVAL.Evaluations.TimeDependentConcordance import (
-    _normalize_time_dependent_method,
-    _select_risk_anchors,
-    concordance_time_dependent,
+    _concordance_from_risk_batches,
+    _prepare_concordance,
 )
 from SurvivalEVAL.Evaluations.util import (
     align_curve_and_time_coordinates,
@@ -53,6 +51,29 @@ from SurvivalEVAL.Evaluations.util import (
     zero_padding,
 )
 from SurvivalEVAL.Evaluations.util_plots import pp_plot
+
+
+def _predict_hazards_from_curve(
+    survival_curve: np.ndarray,
+    time_grid: np.ndarray,
+    target_times: np.ndarray,
+) -> np.ndarray:
+    """Estimate piecewise-constant hazards from one aligned survival curve."""
+    if survival_curve.size < 2:
+        raise ValueError("At least two time points are required to estimate hazards.")
+    if np.any(target_times > time_grid[-1]):
+        raise ValueError(
+            "target_times must not exceed the largest time coordinate when "
+            "estimating hazard rates."
+        )
+
+    interval_indices = np.searchsorted(time_grid[1:], target_times, side="left")
+    interval_indices = np.clip(interval_indices, 0, time_grid.size - 2)
+    epsilon = 1e-12
+    left_survival = np.clip(survival_curve[interval_indices], epsilon, None)
+    right_survival = np.clip(survival_curve[interval_indices + 1], epsilon, None)
+    interval_widths = time_grid[interval_indices + 1] - time_grid[interval_indices]
+    return -np.log(right_survival / left_survival) / interval_widths
 
 
 class SurvivalEvaluator:
@@ -368,9 +389,9 @@ class SurvivalEvaluator:
         elif self.ndim_surv == 1 and self.ndim_time == 2:
             n_samples = self._time_coordinates.shape[0]
         elif self.ndim_surv == 2 and self.ndim_time == 2:
-            assert (
-                self._pred_survs.shape[0] == self._time_coordinates.shape[0]
-            ), "The number of samples in pred_survs and time_coordinates must be the same"
+            assert self._pred_survs.shape[0] == self._time_coordinates.shape[0], (
+                "The number of samples in pred_survs and time_coordinates must be the same"
+            )
             n_samples = self._pred_survs.shape[0]
         else:
             raise TypeError("Dimensional error")
@@ -418,6 +439,57 @@ class SurvivalEvaluator:
 
         return predict_probs
 
+    @staticmethod
+    def _fill_multi_curve_predictions(
+        output: np.ndarray,
+        sample_indices: np.ndarray,
+        survival_curves: np.ndarray,
+        time_grids: np.ndarray,
+        target_times: np.ndarray,
+        predictor: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray],
+        target_counts: np.ndarray | None = None,
+    ) -> None:
+        """Fill selected curve predictions, optionally using row prefixes."""
+        for output_row_index, sample_index in enumerate(sample_indices):
+            target_count = (
+                target_times.size
+                if target_counts is None
+                else int(target_counts[output_row_index])
+            )
+            if target_count == 0:
+                continue
+            output[output_row_index, :target_count] = predictor(
+                survival_curves[sample_index],
+                time_grids[sample_index],
+                target_times[:target_count],
+            )
+
+    def _predict_multi_curve_values(
+        self,
+        target_times: np.ndarray,
+        predictor: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray],
+        dtype: np.dtype,
+    ) -> np.ndarray:
+        """Evaluate one curve predictor for every testing sample."""
+        survival_curves, time_grids = align_curve_and_time_coordinates(
+            self._pred_survs,
+            self._time_coordinates,
+            n_samples=self._testing_sample_count(),
+        )
+        output = np.empty(
+            (survival_curves.shape[0], target_times.size),
+            dtype=dtype,
+        )
+        self._fill_multi_curve_predictions(
+            output,
+            np.arange(survival_curves.shape[0]),
+            survival_curves,
+            time_grids,
+            target_times,
+            predictor,
+        )
+        return output
+
     def predict_multi_probabilities_from_curve(
         self, target_times: np.ndarray
     ) -> np.ndarray:
@@ -436,43 +508,16 @@ class SurvivalEvaluator:
         """
         target_times = validate_time_points(target_times, input_name="target_times")
 
-        if self.ndim_surv == 2 and self.ndim_time == 1:
-            n_samples = self._pred_survs.shape[0]
-            prob_mat = np.empty(
-                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
-            )
-
-            for i, curve in enumerate(self._pred_survs):
-                prob_mat[i] = predict_multi_probs_from_curve(
-                    curve, self.time_coordinates, target_times, self.interpolation
-                )
-        elif self.ndim_surv == 1 and self.ndim_time == 2:
-            n_samples = self._time_coordinates.shape[0]
-            prob_mat = np.empty(
-                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
-            )
-
-            for i, times in enumerate(self._time_coordinates):
-                prob_mat[i] = predict_multi_probs_from_curve(
-                    self._pred_survs, times, target_times, self.interpolation
-                )
-        elif self.ndim_surv == 2 and self.ndim_time == 2:
-            n_samples = self._pred_survs.shape[0]
-            prob_mat = np.empty(
-                (n_samples, target_times.shape[0]), dtype=self._pred_survs.dtype
-            )
-
-            for i in range(n_samples):
-                prob_mat[i] = predict_multi_probs_from_curve(
-                    self._pred_survs[i, :],
-                    self._time_coordinates[i, :],
-                    target_times,
-                    self.interpolation,
-                )
-        else:
-            raise TypeError("Dimensional error")
-
-        return prob_mat
+        return self._predict_multi_curve_values(
+            target_times,
+            lambda curve, times, targets: predict_multi_probs_from_curve(
+                curve,
+                times,
+                targets,
+                self.interpolation,
+            ),
+            self._pred_survs.dtype,
+        )
 
     def predict_multi_hazards_from_curve(self, target_times: np.ndarray) -> np.ndarray:
         """
@@ -491,41 +536,11 @@ class SurvivalEvaluator:
         """
         target_times = validate_time_points(target_times, input_name="target_times")
 
-        survival_curves, time_grids = align_curve_and_time_coordinates(
-            self._pred_survs,
-            self._time_coordinates,
-            n_samples=self._testing_sample_count(),
+        return self._predict_multi_curve_values(
+            target_times,
+            _predict_hazards_from_curve,
+            np.dtype(float),
         )
-        if survival_curves.shape[1] < 2:
-            raise ValueError(
-                "At least two time points are required to estimate hazards."
-            )
-
-        hazard_mat = np.empty(
-            (survival_curves.shape[0], target_times.shape[0]), dtype=float
-        )
-        eps = 1e-12
-
-        for i, (survival_curve, time_grid) in enumerate(
-            zip(survival_curves, time_grids)
-        ):
-            if np.any(target_times > time_grid[-1]):
-                raise ValueError(
-                    "target_times must not exceed the largest time coordinate "
-                    "when estimating hazard rates."
-                )
-
-            interval_indices = np.searchsorted(time_grid[1:], target_times, side="left")
-            interval_indices = np.clip(interval_indices, 0, time_grid.shape[0] - 2)
-            left_survival = np.clip(survival_curve[interval_indices], eps, None)
-            right_survival = np.clip(survival_curve[interval_indices + 1], eps, None)
-            interval_widths = (
-                time_grid[interval_indices + 1] - time_grid[interval_indices]
-            )
-
-            hazard_mat[i] = -np.log(right_survival / left_survival) / interval_widths
-
-        return hazard_mat
 
     def predict_interval(
         self,
@@ -862,15 +877,13 @@ class SurvivalEvaluator:
         method: str = "Antolini",
         risks: str = "Survival",
         tau: Numeric | None = None,
+        working_memory: Numeric = 256,
     ) -> tuple[float, float, float]:
         """
         Calculate the time-dependent concordance index.
 
-        Risk scores are evaluated at sample-level observed-event anchor times.
-        If multiple observed events share the same time, that time is represented
-        once per observed event anchor, not once per unique event time. The
-        evaluator predicts each contributing unique time once, then expands it
-        to preserve the lower-level sample-level column contract.
+        Risks are evaluated at unique event times and streamed in bounded
+        subject batches. The full sample-by-event-time matrix is never created.
 
         Parameters
         ----------
@@ -891,7 +904,8 @@ class SurvivalEvaluator:
             with samples whose observed event/censoring time is greater than t_i.
             "Naive": alias of "Antolini".
             "IPCW": Antolini-style comparable pairs weighted by inverse probability
-            of censoring weights from the training data.
+            of censoring weights from the training data. Contributing event times
+            must be within the training-time support.
         risks: str, default = "Survival"
             A string indicating the type of risk scores to be used for concordance calculation.
             Options are "Survival" (default) and "Hazard".
@@ -899,9 +913,11 @@ class SurvivalEvaluator:
             using -S(t | z).
             "Hazard": predicted hazard rates at anchor event times are used directly as risk scores.
         tau: float, optional (default=None)
-            Truncation time. If provided, only pairs whose effective earlier or
-            anchor time is strictly before ``tau`` are counted. If None, no
-            truncation is applied.
+            Non-negative finite truncation time. Event anchors at ``tau`` are
+            excluded; later subjects remain candidates for earlier anchors.
+        working_memory: float, default=256
+            Target MiB for the compact risk buffer. If one complete compact row
+            exceeds the target, one row is still allocated.
 
         Returns
         -------
@@ -912,78 +928,68 @@ class SurvivalEvaluator:
         num_total_pairs: float
             The number of total pairs.
         """
-        # With fully observed outcomes, Antolini's comparable-pair method is sufficient.
-        risks = risks.lower()
+        if not isinstance(risks, str):
+            raise TypeError("risks must be a string.")
+        normalized_risks = risks.lower()
 
-        if self._NO_CENSOR:
-            method = "antolini"
-
-        method = _normalize_time_dependent_method(method)
-        ties = _normalize_ties(ties)
-
-        if risks not in {"survival", "hazard"}:
-            error = (
-                "Risks must be 'Survival' or 'Hazard', "
-                f"got '{risks}' instead"
-            )
+        if normalized_risks not in {"survival", "hazard"}:
+            error = f"Risks must be 'Survival' or 'Hazard', got '{risks}' instead"
             raise ValueError(error)
 
-        if method == "ipcw":
-            self._error_trainset("IPCW time-dependent concordance")
-
-        event_indicators = self.event_indicators.astype(bool, copy=False)
         n_samples = self.event_times.shape[0]
-        anchor_times, included_anchor_mask = _select_risk_anchors(
-            self.event_times, event_indicators, tau
+        prepared = _prepare_concordance(
+            self.event_times,
+            self.event_indicators,
+            self.train_event_times,
+            self.train_event_indicators,
+            method,
+            ties,
+            tau,
+            working_memory,
         )
-        n_anchors = anchor_times.size
-        if n_anchors == 0:
-            raise ValueError(
-                "Data has no observed events, cannot estimate time-dependent concordance index."
-            )
+        survival_curves, time_grids = align_curve_and_time_coordinates(
+            self._pred_survs,
+            self._time_coordinates,
+            n_samples=n_samples,
+        )
 
-        included_anchor_times = anchor_times[included_anchor_mask]
+        if normalized_risks == "survival":
 
-        if included_anchor_times.size > 0:
-            unique_anchor_times, inverse = np.unique(
-                included_anchor_times, return_inverse=True
-            )
-            if risks == "survival":
-                unique_risk_scores = self.predict_multi_probabilities_from_curve(
-                    unique_anchor_times
+            def predict_curve_risks(curve, times, targets):
+                probabilities = predict_multi_probs_from_curve(
+                    curve,
+                    times,
+                    targets,
+                    self.interpolation,
                 )
-                np.negative(unique_risk_scores, out=unique_risk_scores)
-            else:
-                unique_risk_scores = self.predict_multi_hazards_from_curve(
-                    unique_anchor_times
-                )
+                return np.negative(probabilities, out=probabilities)
 
-            # Expand unique-time risks directly into the required sample-level
-            # anchor matrix. Inactive columns are placeholders that the pair
-            # counter never reads.
-            unique_column_by_anchor = np.zeros(n_anchors, dtype=int)
-            unique_column_by_anchor[included_anchor_mask] = inverse
-            risk_scores = np.empty((n_samples, n_anchors), dtype=float)
-            np.take(
-                unique_risk_scores,
-                unique_column_by_anchor,
-                axis=1,
-                out=risk_scores,
-            )
-            risk_scores[:, ~included_anchor_mask] = 0.0
-            del unique_risk_scores, unique_column_by_anchor, inverse
         else:
-            risk_scores = np.zeros((n_samples, n_anchors), dtype=float)
+            predict_curve_risks = _predict_hazards_from_curve
 
-        return concordance_time_dependent(
-            risk_scores=risk_scores,
-            event_times=self.event_times,
-            event_indicators=self.event_indicators,
-            train_event_times=self.train_event_times,
-            train_event_indicators=self.train_event_indicators,
-            method=method,
-            ties=ties,
-            tau=tau,
+        risk_times = prepared.layout.risk_times
+
+        def fill_risk_batch(
+            sample_indices: np.ndarray,
+            risk_prefixes: np.ndarray,
+            output: np.ndarray,
+        ) -> None:
+            self._fill_multi_curve_predictions(
+                output,
+                sample_indices,
+                survival_curves,
+                time_grids,
+                risk_times[: output.shape[1]],
+                predict_curve_risks,
+                risk_prefixes,
+            )
+
+        # Curve interpolation and hazard calculations are performed in float64
+        # so values on opposite sides of the risk-tie tolerance stay distinct.
+        return _concordance_from_risk_batches(
+            prepared,
+            np.dtype(float),
+            fill_risk_batch,
         )
 
     def brier_score(
@@ -1604,7 +1610,7 @@ class SurvivalEvaluator:
 
             # label the y positions
             y_labels = [
-                f"[{i/num_bins:.2f}, {(i+1)/num_bins:.2f}{')' if i < num_bins - 1 else ']'}"
+                f"[{i / num_bins:.2f}, {(i + 1) / num_bins:.2f}{')' if i < num_bins - 1 else ']'}"
                 for i in range(num_bins)
             ]
             y_positions = (optimal_cdf[:-1] + optimal_cdf[1:]) / 2  # midpoints of bins
@@ -1719,9 +1725,7 @@ class SurvivalEvaluator:
             survival curve and the Kaplan-Meier estimate. Lower is better.
         """
         if self.ndim_time == 1:
-            average_survival_curve = np.mean(
-                self._pred_survs, axis=0, dtype=float
-            )
+            average_survival_curve = np.mean(self._pred_survs, axis=0, dtype=float)
             calibration_times = self._time_coordinates
         else:
             calibration_times = np.unique(self.event_times[self.event_indicators == 1])

--- a/tests/test_time_dependent_concordance.py
+++ b/tests/test_time_dependent_concordance.py
@@ -1,456 +1,1138 @@
+import itertools
+import tracemalloc
+
 import numpy as np
 import pytest
 
 from SurvivalEVAL import SurvivalEvaluator
-from SurvivalEVAL.Evaluations._concordance_utils import _ConcordanceCounts
+from SurvivalEVAL.Evaluations import TimeDependentConcordance as td_concordance
 from SurvivalEVAL.Evaluations.TimeDependentConcordance import (
-    _select_risk_anchors,
-    _time_dependent_risk_counts,
     concordance_time_dependent,
 )
-from SurvivalEVAL.NonparametricEstimator.SingleEvent import KaplanMeier
 
 
-def _add_time_dependent_pair(
-    counts,
+def _python_number(value):
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    return float(value)
+
+
+def _oracle_censoring_survival(
+    time,
+    train_event_times,
+    train_event_indicators,
+):
+    query = _python_number(time)
+    train_times = [_python_number(value) for value in train_event_times]
+    if query > max(train_times):
+        raise ValueError("outside training support")
+
+    survival = 1.0
+    for jump_time in sorted(set(train_times)):
+        if jump_time > query:
+            break
+        at_risk = sum(value >= jump_time for value in train_times)
+        censorings = sum(
+            value == jump_time and not bool(indicator)
+            for value, indicator in zip(train_times, train_event_indicators)
+        )
+        survival *= 1.0 - censorings / at_risk
+    if survival <= 0:
+        raise ValueError("zero censoring survival")
+    return survival
+
+
+def _oracle_time_dependent_concordance(
     risk_scores,
-    anchor_col_by_sample,
-    anchor,
-    candidate,
-    weight=1.0,
+    risk_times,
+    event_times,
+    event_indicators,
+    *,
+    method="Antolini",
+    ties="Risk",
+    tau=None,
+    train_event_times=None,
+    train_event_indicators=None,
     tied_tol=1e-8,
 ):
-    anchor_col = anchor_col_by_sample[anchor]
-    risk_diff = risk_scores[candidate, anchor_col] - risk_scores[anchor, anchor_col]
-    if abs(risk_diff) <= tied_tol:
-        counts.risk_tie_pairs += weight
-    elif risk_diff < 0:
-        counts.concordant += weight
-    else:
-        counts.discordant += weight
+    """Independent pair-enumeration oracle with its own IPCW estimator."""
+    method = method.lower()
+    ties = ties.lower()
+    times = [_python_number(value) for value in event_times]
+    coordinates = [_python_number(value) for value in risk_times]
+    indicators = [bool(value) for value in event_indicators]
+    tau_value = None if tau is None else _python_number(tau)
+    integer_risks = np.issubdtype(np.asarray(risk_scores).dtype, np.integer)
 
+    concordant = 0.0
+    discordant = 0.0
+    risk_ties = 0.0
+    time_ties = 0.0
+    has_raw_pair = False
+    weight_cache = {}
 
-def _before_tau(time, tau):
-    return tau is None or time < tau
+    def before_tau(time):
+        return tau_value is None or time < tau_value
 
+    def pair_weight(time):
+        if method != "ipcw":
+            return 1.0
+        if time not in weight_cache:
+            survival = _oracle_censoring_survival(
+                time,
+                train_event_times,
+                train_event_indicators,
+            )
+            weight_cache[time] = 1.0 / survival**2
+        return weight_cache[time]
 
-def _reference_risk_anchor_mask(event_times, event_indicators, tau):
-    event_indicators = event_indicators.astype(bool)
-    anchor_times = event_times[event_indicators]
-    included_by_sample = np.zeros(event_times.shape[0], dtype=bool)
-    for anchor_time in np.unique(anchor_times):
-        if tau is not None and anchor_time >= tau:
-            continue
-        same_time = event_times == anchor_time
-        has_candidate = np.any(event_times > anchor_time) or np.any(
-            same_time & ~event_indicators
-        )
-        if has_candidate:
-            included_by_sample[same_time & event_indicators] = True
-    return anchor_times, included_by_sample[event_indicators]
-
-
-def _brute_time_dependent_counts(
-    event_indicators,
-    event_times,
-    risk_scores,
-    sample_weights=None,
-    anchor_pair_weights=None,
-    tau=None,
-):
-    if sample_weights is None:
-        sample_weights = np.ones(event_times.shape[0], dtype=float)
-
-    event_indicators = event_indicators.astype(bool)
-    anchor_indices = np.flatnonzero(event_indicators)
-    anchor_col_by_sample = np.full(event_times.shape[0], -1, dtype=int)
-    anchor_col_by_sample[anchor_indices] = np.arange(anchor_indices.shape[0])
-
-    counts = _ConcordanceCounts()
-    for i in range(event_times.shape[0]):
-        for j in range(i + 1, event_times.shape[0]):
+    for first in range(len(times)):
+        for second in range(first + 1, len(times)):
             if (
-                event_indicators[i]
-                and event_indicators[j]
-                and event_times[i] == event_times[j]
-                and _before_tau(event_times[i], tau)
+                indicators[first]
+                and indicators[second]
+                and times[first] == times[second]
+                and before_tau(times[first])
             ):
-                counts.time_tie_pairs += sample_weights[i] * sample_weights[j]
+                has_raw_pair = True
+                weight = pair_weight(times[first]) if ties in {"time", "all"} else 1.0
+                time_ties += weight
 
-    for i in range(event_times.shape[0]):
-        if not event_indicators[i] or not _before_tau(event_times[i], tau):
+    for anchor, anchor_time in enumerate(times):
+        if not indicators[anchor] or not before_tau(anchor_time):
             continue
-
-        for j in range(event_times.shape[0]):
-            if i == j:
-                continue
-            is_later = event_times[j] > event_times[i]
-            is_same_time_censored = (
-                event_times[j] == event_times[i] and not event_indicators[j]
+        candidates = [
+            sample
+            for sample, sample_time in enumerate(times)
+            if sample != anchor
+            and (
+                sample_time > anchor_time
+                or (sample_time == anchor_time and not indicators[sample])
             )
-            if not (is_later or is_same_time_censored):
-                continue
+        ]
+        if not candidates:
+            continue
+        has_raw_pair = True
+        try:
+            risk_column = next(
+                index
+                for index, coordinate in enumerate(coordinates)
+                if coordinate == anchor_time
+            )
+        except StopIteration as error:
+            raise ValueError("missing risk coordinate") from error
+        weight = pair_weight(anchor_time)
+        anchor_risk = risk_scores[anchor, risk_column]
 
-            if anchor_pair_weights is None:
-                weight = sample_weights[i] * sample_weights[j]
+        for candidate in candidates:
+            candidate_risk = risk_scores[candidate, risk_column]
+            if integer_risks:
+                difference = int(candidate_risk) - int(anchor_risk)
             else:
-                weight = anchor_pair_weights[i]
-            _add_time_dependent_pair(
-                counts, risk_scores, anchor_col_by_sample, i, j, weight=weight
-            )
+                difference = float(candidate_risk) - float(anchor_risk)
+            if abs(difference) <= tied_tol:
+                risk_ties += weight
+            elif difference < 0:
+                concordant += weight
+            else:
+                discordant += weight
 
-    return counts
-
-
-def test_time_dependent_antolini_perfect_and_reversed_rankings():
-    event_times = np.array([1.0, 2.0, 3.0])
-    event_indicators = np.array([1, 1, 1])
-    perfect_scores = np.array(
-        [
-            [3.0, 0.0, 0.0],
-            [2.0, 3.0, 0.0],
-            [1.0, 2.0, 0.0],
-        ]
-    )
-    reversed_scores = np.array(
-        [
-            [1.0, 0.0, 0.0],
-            [2.0, 1.0, 0.0],
-            [3.0, 2.0, 0.0],
-        ]
-    )
-
-    perfect = concordance_time_dependent(perfect_scores, event_times, event_indicators)
-    reversed_result = concordance_time_dependent(
-        reversed_scores, event_times, event_indicators
-    )
-
-    np.testing.assert_allclose(perfect, (1.0, 3.0, 3.0))
-    np.testing.assert_allclose(reversed_result, (0.0, 0.0, 3.0))
+    if not has_raw_pair:
+        return None
+    numerator = concordant
+    denominator = concordant + discordant
+    if ties in {"risk", "all"}:
+        numerator += 0.5 * risk_ties
+        denominator += risk_ties
+    if ties in {"time", "all"}:
+        numerator += 0.5 * time_ties
+        denominator += time_ties
+    c_index = numerator / denominator if denominator else float("nan")
+    return c_index, numerator, denominator
 
 
-def test_time_dependent_antolini_risk_ties_use_existing_tie_policy():
-    risk_scores = np.ones((3, 3))
-    event_times = np.array([1.0, 2.0, 3.0])
-    event_indicators = np.array([1, 1, 1])
-
-    with_risk_ties = concordance_time_dependent(
-        risk_scores, event_times, event_indicators, ties="Risk"
-    )
-    without_ties = concordance_time_dependent(
-        risk_scores, event_times, event_indicators, ties="None"
-    )
-
-    np.testing.assert_allclose(with_risk_ties, (0.5, 1.5, 3.0))
-    assert np.isnan(without_ties[0])
-    assert without_ties[1:] == (0.0, 0.0)
+def _assert_result_equal(actual, expected):
+    assert expected is not None
+    if np.isnan(expected[0]):
+        assert np.isnan(actual[0])
+        np.testing.assert_allclose(actual[1:], expected[1:])
+    else:
+        np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
 
 
-def test_time_dependent_antolini_time_ties_are_not_comparable_risk_pairs():
-    risk_scores = np.array(
-        [
-            [3.0, 3.0, 0.0],
-            [2.0, 2.0, 0.0],
-            [1.0, 1.0, 0.0],
-        ]
-    )
-    event_times = np.array([1.0, 1.0, 2.0])
-    event_indicators = np.array([1, 1, 1])
+def test_exhaustive_small_datasets_match_independent_oracle():
+    risk_times = np.array([0.0, 1.0, 2.0, 4.0])
+    train_times = np.array([0.0, 1.0, 2.0, 3.0, 3.0])
+    train_indicators = np.array([1, 0, 1, 0, 1])
 
-    risk_only = concordance_time_dependent(
-        risk_scores, event_times, event_indicators, ties="Risk"
-    )
-    with_time_ties = concordance_time_dependent(
-        risk_scores, event_times, event_indicators, ties="Time"
-    )
-
-    np.testing.assert_allclose(risk_only, (1.0, 2.0, 2.0))
-    np.testing.assert_allclose(with_time_ties, (5.0 / 6.0, 2.5, 3.0))
-
-
-def test_private_time_dependent_counts_match_brute_force_for_random_small_inputs():
-    rng = np.random.default_rng(2)
-
-    for n_samples in range(2, 10):
-        for _ in range(50):
-            event_times = rng.integers(1, 6, size=n_samples).astype(float)
-            event_indicators = rng.random(n_samples) < 0.65
-            if not np.any(event_indicators):
-                event_indicators[rng.integers(0, n_samples)] = True
-            risk_scores = rng.integers(
-                -2, 3, size=(n_samples, int(event_indicators.sum()))
+    for event_times_tuple in itertools.product(range(3), repeat=3):
+        event_times = np.asarray(event_times_tuple, dtype=float)
+        for indicators_tuple in itertools.product((0, 1), repeat=3):
+            if not any(indicators_tuple):
+                continue
+            event_indicators = np.asarray(indicators_tuple)
+            risk_scores = np.fromfunction(
+                lambda row, column: (3 * row + 2 * column) % 5,
+                (3, risk_times.size),
+                dtype=int,
             ).astype(float)
-            sample_weights = rng.uniform(0.25, 2.0, size=n_samples)
-            anchor_pair_weights = rng.uniform(0.25, 2.0, size=n_samples)
-            tau = float(rng.integers(1, 6))
 
-            actual = _time_dependent_risk_counts(
+            for tau, ties, method, working_memory in itertools.product(
+                (None, 1.0, 2.0),
+                ("None", "Time", "Risk", "All"),
+                ("Antolini", "Naive", "IPCW"),
+                (1e-6, 1.0),
+            ):
+                kwargs = {
+                    "method": method,
+                    "ties": ties,
+                    "tau": tau,
+                    "working_memory": working_memory,
+                }
+                oracle_kwargs = {
+                    "method": method,
+                    "ties": ties,
+                    "tau": tau,
+                }
+                if method == "IPCW":
+                    kwargs.update(
+                        train_event_times=train_times,
+                        train_event_indicators=train_indicators,
+                    )
+                    oracle_kwargs.update(
+                        train_event_times=train_times,
+                        train_event_indicators=train_indicators,
+                    )
+                expected = _oracle_time_dependent_concordance(
+                    risk_scores,
+                    risk_times,
+                    event_times,
+                    event_indicators,
+                    **oracle_kwargs,
+                )
+                if expected is None:
+                    with pytest.raises(ValueError, match="no comparable pairs"):
+                        concordance_time_dependent(
+                            risk_scores,
+                            risk_times,
+                            event_times,
+                            event_indicators,
+                            **kwargs,
+                        )
+                else:
+                    actual = concordance_time_dependent(
+                        risk_scores,
+                        risk_times,
+                        event_times,
+                        event_indicators,
+                        **kwargs,
+                    )
+                    _assert_result_equal(actual, expected)
+
+
+@pytest.mark.parametrize("risk_dtype", [np.int64, np.uint64, np.float32, np.float64])
+def test_randomized_permutations_and_batches_match_independent_oracle(risk_dtype):
+    rng = np.random.default_rng(20260905)
+    train_times = np.array([0, 1, 2, 3, 4, 5, 6], dtype=np.int64)
+    train_indicators = np.array([1, 0, 1, 1, 0, 1, 1])
+
+    for _ in range(30):
+        n_samples = int(rng.integers(2, 9))
+        event_times = rng.integers(0, 6, size=n_samples)
+        event_indicators = rng.integers(0, 2, size=n_samples)
+        event_indicators[int(rng.integers(n_samples))] = 1
+        risk_times = np.arange(0, 6.5, 0.5)
+        raw_risks = rng.integers(0, 8, size=(n_samples, risk_times.size))
+        if np.issubdtype(risk_dtype, np.floating):
+            raw_risks = raw_risks + rng.choice(
+                [0.0, 0.5e-8, 1.0e-8, 1.5e-8],
+                size=raw_risks.shape,
+            )
+        risk_scores = raw_risks.astype(risk_dtype)
+        permutation = rng.permutation(n_samples)
+        event_times = event_times[permutation]
+        event_indicators = event_indicators[permutation]
+        risk_scores = risk_scores[permutation]
+        tau = rng.choice([None, 1, 3, 5])
+
+        for method, ties, working_memory in itertools.product(
+            ("Antolini", "Naive", "IPCW"),
+            ("None", "Time", "Risk", "All"),
+            (1e-6, 0.01),
+        ):
+            kwargs = {
+                "method": method,
+                "ties": ties,
+                "tau": tau,
+                "working_memory": working_memory,
+            }
+            oracle_kwargs = {"method": method, "ties": ties, "tau": tau}
+            if method == "IPCW":
+                kwargs.update(
+                    train_event_times=train_times,
+                    train_event_indicators=train_indicators,
+                )
+                oracle_kwargs.update(
+                    train_event_times=train_times,
+                    train_event_indicators=train_indicators,
+                )
+            expected = _oracle_time_dependent_concordance(
                 risk_scores,
+                risk_times,
                 event_times,
                 event_indicators,
-                sample_weights=sample_weights,
-                anchor_pair_weights=anchor_pair_weights,
-                tau=tau,
+                **oracle_kwargs,
             )
-            expected = _brute_time_dependent_counts(
-                event_indicators,
-                event_times,
-                risk_scores,
-                sample_weights=sample_weights,
-                anchor_pair_weights=anchor_pair_weights,
-                tau=tau,
-            )
+            if expected is None:
+                with pytest.raises(ValueError, match="no comparable pairs"):
+                    concordance_time_dependent(
+                        risk_scores,
+                        risk_times,
+                        event_times,
+                        event_indicators,
+                        **kwargs,
+                    )
+            else:
+                actual = concordance_time_dependent(
+                    risk_scores,
+                    risk_times,
+                    event_times,
+                    event_indicators,
+                    **kwargs,
+                )
+                _assert_result_equal(actual, expected)
 
-            assert np.isclose(actual.concordant, expected.concordant)
-            assert np.isclose(actual.discordant, expected.discordant)
-            assert np.isclose(actual.risk_tie_pairs, expected.risk_tie_pairs)
-            assert np.isclose(actual.time_tie_pairs, expected.time_tie_pairs)
 
-
-def test_time_dependent_ipcw_uses_squared_anchor_weights():
-    event_times = np.array([1.0, 2.0, 3.0, 4.0])
-    event_indicators = np.array([1, 1, 1, 1])
+def test_repeated_events_share_one_column_and_extra_coordinates_are_ignored():
+    event_times = np.array([1.0, 1.0, 2.0, 3.0])
+    event_indicators = np.array([1, 1, 0, 1])
+    risk_times = np.array([0.5, 1.0, 1.5, 8.0])
     risk_scores = np.array(
         [
-            [4.0, 0.0, 0.0, 0.0],
-            [3.0, 4.0, 0.0, 0.0],
-            [2.0, 3.0, 4.0, 0.0],
-            [1.0, 2.0, 3.0, 0.0],
+            [-99.0, 4.0, 99.0, -99.0],
+            [-99.0, 3.0, 99.0, -99.0],
+            [-99.0, 2.0, 99.0, -99.0],
+            [-99.0, 1.0, 99.0, -99.0],
         ]
     )
-    train_event_times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-    train_event_indicators = np.array([1, 0, 1, 0, 1])
 
-    c_index, concordant, total = concordance_time_dependent(
+    expected = _oracle_time_dependent_concordance(
         risk_scores,
+        risk_times,
         event_times,
         event_indicators,
-        train_event_times=train_event_times,
-        train_event_indicators=train_event_indicators,
-        method="IPCW",
+        ties="All",
+    )
+    actual = concordance_time_dependent(
+        risk_scores,
+        risk_times,
+        event_times,
+        event_indicators,
+        ties="All",
     )
 
-    censoring_model = KaplanMeier(
-        train_event_times, ~train_event_indicators.astype(bool)
+    _assert_result_equal(actual, expected)
+    np.testing.assert_allclose(actual, (0.9, 4.5, 5.0))
+
+
+@pytest.mark.parametrize("risk_dtype", [np.int64, np.uint64])
+def test_integer_risk_ordering_is_exact_at_dtype_boundaries(risk_dtype):
+    if risk_dtype == np.int64:
+        high = np.iinfo(np.int64).max
+        low = np.iinfo(np.int64).min
+    else:
+        high = np.iinfo(np.uint64).max
+        low = 0
+    result = concordance_time_dependent(
+        np.array([[high], [low]], dtype=risk_dtype),
+        np.array([1]),
+        np.array([1, 2]),
+        np.array([1, 1]),
+        working_memory=1e-9,
     )
-    censoring_survival = censoring_model.predict(event_times)
-    anchor_weights = 1 / np.square(censoring_survival)
-    expected_total = 3 * anchor_weights[0] + 2 * anchor_weights[1] + anchor_weights[2]
-
-    assert np.isclose(c_index, 1.0)
-    assert np.isclose(concordant, expected_total)
-    assert np.isclose(total, expected_total)
+    np.testing.assert_allclose(result, (1.0, 1.0, 1.0))
 
 
-def test_time_dependent_ipcw_tau_excludes_boundary_anchor_and_allows_later_candidates():
-    event_times = np.array([1.0, 2.0, 4.0])
-    event_indicators = np.array([1, 1, 1])
-    risk_scores = np.array(
-        [
-            [3.0, 0.0, 0.0],
-            [2.0, 3.0, 0.0],
-            [1.0, 2.0, 0.0],
-        ]
+@pytest.mark.parametrize("risk_dtype", [np.int64, np.uint64])
+def test_integer_risks_above_float_precision_do_not_collapse(risk_dtype):
+    boundary = 2**53
+    scores = np.array([[boundary + 1], [boundary]], dtype=risk_dtype)
+    np.testing.assert_allclose(
+        concordance_time_dependent(
+            scores,
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+        ),
+        (1.0, 1.0, 1.0),
     )
+
+
+@pytest.mark.parametrize("risk_dtype", [np.float32, np.float64])
+def test_floating_risk_tolerance_boundaries_match_oracle(risk_dtype):
+    risk_times = np.array([1.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    indicators = np.array([1, 0, 0, 0])
+    scores = np.array([[0.0], [-0.5e-8], [1.0e-8], [1.5e-8]], dtype=risk_dtype)
+
+    actual = concordance_time_dependent(
+        scores,
+        risk_times,
+        event_times,
+        indicators,
+        ties="Risk",
+    )
+    expected = _oracle_time_dependent_concordance(
+        scores,
+        risk_times,
+        event_times,
+        indicators,
+        ties="Risk",
+    )
+    _assert_result_equal(actual, expected)
+
+
+def test_finite_float_extremes_are_compared_without_overflow_errors():
+    maximum = np.finfo(np.float64).max
+    result = concordance_time_dependent(
+        np.array([[maximum], [-maximum]]),
+        np.array([1.0]),
+        np.array([1.0, 2.0]),
+        np.ones(2),
+    )
+    np.testing.assert_allclose(result, (1.0, 1.0, 1.0))
+
+
+def test_mixed_time_matching_is_exact_around_float64_boundary():
+    boundary = 2**53
+    with pytest.raises(ValueError, match="missing"):
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([boundary + 1], dtype=np.uint64),
+            np.array([boundary, boundary + 2], dtype=np.float64),
+            np.array([1, 0]),
+        )
+
+    np.testing.assert_allclose(
+        concordance_time_dependent(
+            np.array([[0.0, 2.0], [3.0, 1.0]]),
+            np.array([boundary, boundary + 1], dtype=np.uint64),
+            np.array([boundary + 1, boundary + 2], dtype=np.int64),
+            np.ones(2),
+        ),
+        (1.0, 1.0, 1.0),
+    )
+
+
+def test_mixed_time_matching_handles_signed_unsigned_limits():
+    boundary = np.iinfo(np.int64).max
+    result = concordance_time_dependent(
+        np.array([[2], [1]], dtype=np.int8),
+        np.array([boundary], dtype=np.int64),
+        np.array([boundary, boundary + 1], dtype=np.uint64),
+        np.array([1, 0]),
+    )
+    np.testing.assert_allclose(result, (1.0, 1.0, 1.0))
+
+
+def test_tau_comparisons_are_exact_at_float32_and_uint64_boundaries():
+    float_boundary = 2**24
+    np.testing.assert_allclose(
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([float_boundary], dtype=np.float32),
+            np.array([float_boundary, float_boundary + 2], dtype=np.float32),
+            np.ones(2),
+            tau=float_boundary + 1,
+        ),
+        (1.0, 1.0, 1.0),
+    )
+
+    uint_boundary = 2**54
+    np.testing.assert_allclose(
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([uint_boundary + 3], dtype=np.uint64),
+            np.array([uint_boundary + 3, uint_boundary + 5], dtype=np.uint64),
+            np.ones(2),
+            tau=np.float64(uint_boundary + 4),
+        ),
+        (1.0, 1.0, 1.0),
+    )
+
+
+def test_arbitrarily_large_integer_tau_remains_valid():
+    np.testing.assert_allclose(
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+            tau=10**400,
+        ),
+        (1.0, 1.0, 1.0),
+    )
+
+
+@pytest.mark.skipif(
+    np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant,
+    reason="np.longdouble does not exceed float64 precision on this platform",
+)
+def test_exact_search_preserves_longdouble_values_around_a_large_integer():
+    integer = 2**100
+    boundary = np.longdouble(integer)
+    below = np.nextafter(boundary, np.longdouble(-np.inf))
+    above = np.nextafter(boundary, np.longdouble(np.inf))
+    coordinates = np.array([below, above], dtype=np.longdouble)
+    query = np.array([integer], dtype=object)
+
+    np.testing.assert_array_equal(
+        td_concordance._searchsorted_exact(coordinates, query, side="left"),
+        [1],
+    )
+    np.testing.assert_array_equal(
+        td_concordance._searchsorted_exact(coordinates, query, side="right"),
+        [1],
+    )
+
+
+@pytest.mark.skipif(
+    np.finfo(np.longdouble).nmant <= np.finfo(np.float64).nmant,
+    reason="np.longdouble does not exceed float64 precision on this platform",
+)
+def test_longdouble_event_immediately_below_integer_tau_is_included():
+    integer_tau = 2**100
+    boundary = np.longdouble(integer_tau)
+    event_time = np.nextafter(boundary, np.longdouble(-np.inf))
 
     result = concordance_time_dependent(
-        risk_scores,
-        event_times,
-        event_indicators,
-        train_event_times=np.array([1.0, 2.0, 4.0]),
-        train_event_indicators=np.array([1, 1, 1]),
-        method="IPCW",
-        tau=2.0,
+        np.array([[2.0], [1.0]]),
+        np.array([event_time], dtype=np.longdouble),
+        np.array([event_time, boundary], dtype=np.longdouble),
+        np.array([1, 0]),
+        tau=integer_tau,
     )
 
-    np.testing.assert_allclose(result, (1.0, 2.0, 2.0))
+    np.testing.assert_allclose(result, (1.0, 1.0, 1.0))
 
 
-def test_time_dependent_ipcw_ignores_zero_censoring_survival_for_discarded_final_time_ties():
-    event_times = np.array([1.0, 2.0, 2.0])
-    event_indicators = np.array([1, 1, 1])
+def test_ipcw_uses_right_continuous_squared_block_weights():
     risk_scores = np.array(
         [
-            [3.0, 0.0, 0.0],
-            [2.0, 3.0, 0.0],
-            [1.0, 2.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [3.0, 4.0, 0.0],
+            [2.0, 3.0, 4.0],
+            [1.0, 2.0, 3.0],
         ]
     )
+    risk_times = np.array([1.0, 2.0, 3.0])
+    event_times = np.array([1.0, 2.0, 3.0, 4.0])
+    indicators = np.ones(4)
+    train_times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    train_indicators = np.array([1, 0, 1, 0, 1])
+
+    actual = concordance_time_dependent(
+        risk_scores,
+        risk_times,
+        event_times,
+        indicators,
+        train_times,
+        train_indicators,
+        method="IPCW",
+    )
+    expected = _oracle_time_dependent_concordance(
+        risk_scores,
+        risk_times,
+        event_times,
+        indicators,
+        method="IPCW",
+        train_event_times=train_times,
+        train_event_indicators=train_indicators,
+    )
+    _assert_result_equal(actual, expected)
+
+
+def test_ipcw_censoring_jump_at_anchor_is_applied_immediately():
     kwargs = {
-        "risk_scores": risk_scores,
-        "event_times": event_times,
-        "event_indicators": event_indicators,
+        "risk_scores": np.array([[3.0], [2.0], [1.0]]),
+        "risk_times": np.array([2.0]),
+        "event_times": np.array([2.0, 3.0, 4.0]),
+        "event_indicators": np.array([1, 0, 0]),
+        "train_event_times": np.array([1.0, 2.0, 3.0, 4.0]),
+        "train_event_indicators": np.array([1, 0, 1, 1]),
+        "method": "IPCW",
+    }
+    result = concordance_time_dependent(**kwargs)
+    # G(2) = 2/3 after the censoring jump, so each of two pairs weighs 9/4.
+    np.testing.assert_allclose(result, (1.0, 4.5, 4.5))
+
+
+def test_ipcw_training_support_and_zero_survival_are_checked_only_when_used():
+    kwargs = {
+        "risk_scores": np.array([[3.0, 0.0], [2.0, 3.0], [1.0, 1.0]]),
+        "risk_times": np.array([1.0, 3.0]),
+        "event_times": np.array([1.0, 3.0, 4.0]),
+        "event_indicators": np.array([1, 1, 0]),
+        "train_event_times": np.array([1.0, 2.0]),
+        "train_event_indicators": np.array([1, 1]),
+        "method": "IPCW",
+    }
+    with pytest.raises(ValueError, match="largest training time"):
+        concordance_time_dependent(**kwargs)
+    np.testing.assert_allclose(
+        concordance_time_dependent(**kwargs, tau=2.0),
+        (1.0, 2.0, 2.0),
+    )
+
+    final_ties = {
+        "risk_scores": np.array([[3.0], [2.0], [1.0]]),
+        "risk_times": np.array([1.0]),
+        "event_times": np.array([1.0, 2.0, 2.0]),
+        "event_indicators": np.array([1, 1, 1]),
         "train_event_times": np.array([1.0, 2.0]),
         "train_event_indicators": np.array([1, 0]),
         "method": "IPCW",
     }
-
-    default_ties = concordance_time_dependent(**kwargs)
-    no_ties = concordance_time_dependent(**kwargs, ties="None")
-
-    np.testing.assert_allclose(default_ties, (1.0, 2.0, 2.0))
-    np.testing.assert_allclose(no_ties, (1.0, 2.0, 2.0))
-    with pytest.raises(ValueError, match="Censoring survival probability is zero"):
-        concordance_time_dependent(**kwargs, ties="Time")
-    with pytest.raises(ValueError, match="Censoring survival probability is zero"):
-        concordance_time_dependent(**kwargs, ties="All")
+    np.testing.assert_allclose(
+        concordance_time_dependent(**final_ties, ties="Risk"),
+        (1.0, 2.0, 2.0),
+    )
+    with pytest.raises(ValueError, match="zero"):
+        concordance_time_dependent(**final_ties, ties="Time")
 
 
-def test_time_dependent_concordance_validates_inputs():
-    event_times = np.array([1.0, 2.0, 3.0])
-    event_indicators = np.array([1, 1, 1])
-    risk_scores = np.ones((3, 3))
-
-    with pytest.raises(ValueError, match="2D array"):
-        concordance_time_dependent(np.ones(3), event_times, event_indicators)
-    with pytest.raises(ValueError, match="same"):
-        concordance_time_dependent(np.ones((2, 3)), event_times, event_indicators)
-    with pytest.raises(ValueError, match="observed events"):
-        concordance_time_dependent(np.ones((3, 2)), event_times, event_indicators)
-    with pytest.raises(ValueError, match="no observed events"):
-        concordance_time_dependent(np.ones((3, 0)), event_times, np.array([0, 0, 0]))
-    with pytest.raises(ValueError, match="Unsupported method"):
+def test_ipcw_mixed_training_support_and_step_lookup_are_exact():
+    boundary = 2**53
+    with pytest.raises(ValueError, match="largest training time"):
         concordance_time_dependent(
-            risk_scores, event_times, event_indicators, method="Harrell"
-        )
-    with pytest.raises(ValueError, match="must be provided"):
-        concordance_time_dependent(
-            risk_scores, event_times, event_indicators, method="IPCW"
-        )
-
-
-def test_survival_evaluator_time_dependent_concordance_end_to_end():
-    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
-    hazards = np.array([0.5, 0.2, 0.1])
-    pred_survs = np.exp(-hazards[:, None] * time_grid)
-
-    fully_observed = SurvivalEvaluator(
-        pred_survs=pred_survs,
-        time_coordinates=time_grid,
-        event_times=np.array([1.0, 2.0, 3.0]),
-        event_indicators=np.array([1, 1, 1]),
-    )
-
-    survival_result = fully_observed.concordance_time_dependent(
-        method="Antolini", risks="Survival"
-    )
-    hazard_result = fully_observed.concordance_time_dependent(
-        method="Antolini", risks="Hazard"
-    )
-
-    np.testing.assert_allclose(survival_result, (1.0, 3.0, 3.0))
-    np.testing.assert_allclose(hazard_result, (1.0, 3.0, 3.0))
-
-    censored = SurvivalEvaluator(
-        pred_survs=pred_survs,
-        time_coordinates=time_grid,
-        event_times=np.array([1.0, 2.0, 3.0]),
-        event_indicators=np.array([1, 0, 1]),
-        train_event_times=np.array([1.0, 2.0, 3.0]),
-        train_event_indicators=np.array([1, 1, 1]),
-    )
-
-    ipcw_survival = censored.concordance_time_dependent(
-        method="IPCW", risks="Survival", tau=2.0
-    )
-    ipcw_hazard = censored.concordance_time_dependent(
-        method="IPCW", risks="Hazard", tau=2.0
-    )
-
-    np.testing.assert_allclose(ipcw_survival, (1.0, 2.0, 2.0))
-    np.testing.assert_allclose(ipcw_hazard, (1.0, 2.0, 2.0))
-
-
-def test_survival_evaluator_hazard_concordance_tau_skips_excluded_late_anchors():
-    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
-    hazards = np.array([0.5, 0.3, 0.1, 0.05])
-    pred_survs = np.exp(-hazards[:, None] * time_grid)
-
-    evaluator = SurvivalEvaluator(
-        pred_survs=pred_survs,
-        time_coordinates=time_grid,
-        event_times=np.array([1.0, 2.0, 10.0, 12.0]),
-        event_indicators=np.array([1, 1, 1, 0]),
-        train_event_times=np.array([1.0, 2.0, 3.0, 4.0]),
-        train_event_indicators=np.array([1, 1, 1, 1]),
-    )
-
-    result = evaluator.concordance_time_dependent(
-        method="IPCW", risks="Hazard", tau=3.0
-    )
-
-    np.testing.assert_allclose(result, (1.0, 5.0, 5.0))
-
-
-def test_survival_evaluator_hazard_concordance_skips_final_anchor_without_candidates():
-    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
-    hazards = np.array([0.5, 0.3, 0.1])
-    pred_survs = np.exp(-hazards[:, None] * time_grid)
-
-    evaluator = SurvivalEvaluator(
-        pred_survs=pred_survs,
-        time_coordinates=time_grid,
-        event_times=np.array([1.0, 2.0, 10.0]),
-        event_indicators=np.array([1, 1, 1]),
-    )
-
-    result = evaluator.concordance_time_dependent(method="Antolini", risks="Hazard")
-
-    np.testing.assert_allclose(result, (1.0, 3.0, 3.0))
-
-
-def test_select_risk_anchors_matches_reference_on_randomized_inputs():
-    rng = np.random.default_rng(20260812)
-    for _ in range(100):
-        n_samples = int(rng.integers(1, 30))
-        event_times = rng.integers(1, 8, size=n_samples).astype(float)
-        event_indicators = rng.integers(0, 2, size=n_samples).astype(bool)
-        event_indicators[int(rng.integers(0, n_samples))] = True
-        tau = None if rng.random() < 0.5 else float(rng.integers(1, 9))
-
-        expected_times, expected_mask = _reference_risk_anchor_mask(
-            event_times, event_indicators, tau
-        )
-        actual_times, actual_mask = _select_risk_anchors(
-            event_times, event_indicators, tau
+            np.array([[2.0], [1.0]]),
+            np.array([boundary + 1], dtype=np.uint64),
+            np.array([boundary + 1, boundary + 2], dtype=np.uint64),
+            np.array([1, 0]),
+            np.array([boundary], dtype=np.float64),
+            np.array([1]),
+            method="IPCW",
         )
 
-        np.testing.assert_array_equal(actual_times, expected_times)
-        np.testing.assert_array_equal(actual_mask, expected_mask)
+    actual = concordance_time_dependent(
+        np.array([[3.0, 0.0], [2.0, 1.0], [1.0, 2.0]]),
+        np.array([boundary, boundary + 1], dtype=np.uint64),
+        np.array([boundary, boundary + 1, boundary + 2], dtype=np.uint64),
+        np.array([1, 1, 0]),
+        np.array([boundary, boundary + 1, boundary + 2], dtype=np.uint64),
+        np.array([1, 0, 1]),
+        method="IPCW",
+    )
+    np.testing.assert_allclose(actual, (1 / 3, 2.0, 6.0))
+
+
+def test_explicit_ipcw_is_honored_for_fully_observed_test_data():
+    scores = np.array([[3.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    common = {
+        "risk_scores": scores,
+        "risk_times": np.array([1.0, 2.0]),
+        "event_times": np.array([1.0, 2.0, 3.0]),
+        "event_indicators": np.ones(3),
+    }
+    antolini = concordance_time_dependent(**common)
+    ipcw = concordance_time_dependent(
+        **common,
+        train_event_times=np.array([1.5, 3.0]),
+        train_event_indicators=np.array([0, 1]),
+        method="IPCW",
+    )
+    np.testing.assert_allclose(antolini, (2 / 3, 2.0, 3.0))
+    np.testing.assert_allclose(ipcw, (1 / 3, 2.0, 6.0))
 
 
 @pytest.mark.parametrize(
-    ("risks", "prediction_method"),
+    ("field", "value", "error_type", "message"),
     [
-        ("Survival", "predict_multi_probabilities_from_curve"),
-        ("Hazard", "predict_multi_hazards_from_curve"),
+        ("risk_scores", np.ones(2), ValueError, "2D array"),
+        ("risk_scores", np.array([[True], [False]]), TypeError, "real numeric"),
+        ("risk_scores", np.array([[1j], [0j]]), TypeError, "real numeric"),
+        ("risk_scores", np.array([["1"], ["0"]]), TypeError, "real numeric"),
+        ("risk_scores", np.array([[np.nan], [0.0]]), ValueError, "finite"),
+        ("risk_scores", np.array([[np.inf], [0.0]]), ValueError, "finite"),
+        ("risk_times", np.array([[1.0]]), ValueError, "1-D"),
+        ("risk_times", np.array([True]), TypeError, "real numeric"),
+        ("risk_times", np.array([1j]), TypeError, "real numeric"),
+        ("risk_times", np.array(["1"]), TypeError, "real numeric"),
+        ("risk_times", np.array([np.nan]), ValueError, "finite"),
+        ("risk_times", np.array([-1.0]), ValueError, "non-negative"),
+        ("event_times", np.array([[1.0, 2.0]]), ValueError, "1-D"),
+        ("event_times", np.array([True, False]), TypeError, "real numeric"),
+        ("event_times", np.array([1j, 2j]), TypeError, "real numeric"),
+        ("event_times", np.array(["1", "2"]), TypeError, "real numeric"),
+        ("event_times", np.array([np.nan, 2.0]), ValueError, "finite"),
+        ("event_times", np.array([-1.0, 2.0]), ValueError, "non-negative"),
+        ("event_indicators", np.array([[1, 0]]), ValueError, "1-D"),
+        ("event_indicators", np.array([1j, 0j]), TypeError, "Boolean or real"),
+        ("event_indicators", np.array(["1", "0"]), TypeError, "Boolean or real"),
+        ("event_indicators", np.array([2, 0]), ValueError, "only 0 and 1"),
+        ("event_indicators", np.array([np.nan, 0]), ValueError, "only 0 and 1"),
     ],
 )
-def test_evaluator_predicts_each_active_anchor_time_once(
-    monkeypatch,
-    risks,
-    prediction_method,
+def test_public_api_rejects_malformed_and_nonfinite_inputs(
+    field,
+    value,
+    error_type,
+    message,
 ):
-    time_grid = np.array([0.0, 1.0, 2.0, 3.0])
+    kwargs = {
+        "risk_scores": np.array([[2.0], [1.0]]),
+        "risk_times": np.array([1.0]),
+        "event_times": np.array([1.0, 2.0]),
+        "event_indicators": np.array([1, 0]),
+    }
+    kwargs[field] = value
+    with pytest.raises(error_type, match=message):
+        concordance_time_dependent(**kwargs)
+
+
+def test_public_api_rejects_shape_grid_and_event_errors():
+    with pytest.raises(ValueError, match="same"):
+        concordance_time_dependent(
+            np.ones((2, 1)),
+            np.array([1.0]),
+            np.array([1.0, 2.0, 3.0]),
+            np.ones(3),
+        )
+    with pytest.raises(ValueError, match="columns"):
+        concordance_time_dependent(
+            np.ones((2, 2)),
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+        )
+    with pytest.raises(ValueError, match="missing"):
+        concordance_time_dependent(
+            np.ones((3, 1)),
+            np.array([1.0]),
+            np.array([1.0, 2.0, 3.0]),
+            np.ones(3),
+        )
+    with pytest.raises(ValueError, match="strictly increasing"):
+        concordance_time_dependent(
+            np.ones((3, 3)),
+            np.array([1, 2, 0], dtype=np.uint64),
+            np.array([1, 2, 3], dtype=np.uint64),
+            np.ones(3),
+        )
+    with pytest.raises(ValueError, match="strictly increasing"):
+        concordance_time_dependent(
+            np.ones((2, 2)),
+            np.array([1.0, 1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+        )
+    with pytest.raises(ValueError, match="no observed events"):
+        concordance_time_dependent(
+            np.empty((2, 0)),
+            np.empty(0),
+            np.array([1.0, 2.0]),
+            np.zeros(2),
+        )
+
+
+@pytest.mark.parametrize(
+    ("tau", "error_type"),
+    [
+        (-1, ValueError),
+        (np.inf, ValueError),
+        (np.nan, ValueError),
+        (True, TypeError),
+        ("2", TypeError),
+        (1 + 0j, TypeError),
+        (np.array([2.0]), TypeError),
+    ],
+)
+def test_tau_validation(tau, error_type):
+    with pytest.raises(error_type, match="tau"):
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+            tau=tau,
+        )
+
+
+@pytest.mark.parametrize(
+    "working_memory",
+    [0, -1, np.inf, np.nan, True, "large", "256", 1 + 0j, 10**400],
+)
+def test_working_memory_validation(working_memory):
+    with pytest.raises(ValueError, match="working_memory"):
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+            working_memory=working_memory,
+        )
+
+
+@pytest.mark.parametrize(
+    ("train_times", "train_indicators", "error_type", "message"),
+    [
+        (None, None, ValueError, "must be provided"),
+        (np.array([]), np.array([]), ValueError, "must not be empty"),
+        (np.array([1.0]), np.array([1, 0]), ValueError, "same shape"),
+        (np.array([np.inf]), np.array([1]), ValueError, "finite"),
+        (np.array([-1.0]), np.array([1]), ValueError, "non-negative"),
+        (np.array(["1"]), np.array([1]), TypeError, "real numeric"),
+        (np.array([1.0]), np.array([2]), ValueError, "only 0 and 1"),
+        (np.array([1.0]), np.array([1j]), TypeError, "Boolean or real"),
+    ],
+)
+def test_ipcw_training_validation(
+    train_times,
+    train_indicators,
+    error_type,
+    message,
+):
+    with pytest.raises(error_type, match=message):
+        concordance_time_dependent(
+            np.array([[2.0], [1.0]]),
+            np.array([1.0]),
+            np.array([1.0, 2.0]),
+            np.ones(2),
+            train_times,
+            train_indicators,
+            method="IPCW",
+        )
+
+
+def test_string_options_are_validated_cleanly():
+    args = (
+        np.array([[2.0], [1.0]]),
+        np.array([1.0]),
+        np.array([1.0, 2.0]),
+        np.ones(2),
+    )
+    with pytest.raises(TypeError, match="method"):
+        concordance_time_dependent(*args, method=True)
+    with pytest.raises(ValueError, match="Unsupported"):
+        concordance_time_dependent(*args, method="Harrell")
+    with pytest.raises(TypeError, match="ties"):
+        concordance_time_dependent(*args, ties=False)
+    with pytest.raises(ValueError, match="handling ties"):
+        concordance_time_dependent(*args, ties="Maybe")
+
+
+@pytest.mark.parametrize("risks", ["Survival", "Hazard"])
+@pytest.mark.parametrize("per_subject_grid", [False, True])
+def test_evaluator_matches_precomputed_lower_level_risks(
+    risks,
+    per_subject_grid,
+):
+    shared_grid = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
     hazards = np.array([0.5, 0.4, 0.2, 0.1])
+    if per_subject_grid:
+        time_grid = np.array(
+            [
+                [0.0, 1.0, 2.0, 3.0, 4.0],
+                [0.0, 0.8, 2.2, 3.4, 4.0],
+                [0.0, 1.2, 2.4, 3.2, 4.0],
+                [0.0, 0.5, 1.5, 3.5, 4.0],
+            ]
+        )
+        pred_survs = np.exp(-hazards[:, None] * time_grid)
+    else:
+        time_grid = shared_grid
+        pred_survs = np.exp(-hazards[:, None] * shared_grid)
+
+    evaluator = SurvivalEvaluator(
+        pred_survs=pred_survs,
+        time_coordinates=time_grid,
+        event_times=np.array([1.0, 1.0, 2.0, 3.0]),
+        event_indicators=np.array([1, 1, 0, 1]),
+    )
+    risk_times = np.array([1.0])
+    if risks == "Survival":
+        risk_scores = -evaluator.predict_multi_probabilities_from_curve(risk_times)
+    else:
+        risk_scores = evaluator.predict_multi_hazards_from_curve(risk_times)
+
+    expected = concordance_time_dependent(
+        risk_scores,
+        risk_times,
+        evaluator.event_times,
+        evaluator.event_indicators,
+    )
+    actual = evaluator.concordance_time_dependent(
+        risks=risks,
+        working_memory=1e-6,
+    )
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_evaluator_honors_explicit_ipcw_for_fully_observed_data():
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.array(
+            [
+                [1.0, 0.2, 0.1, 0.05],
+                [1.0, 0.7, 0.6, 0.4],
+                [1.0, 0.8, 0.5, 0.3],
+            ]
+        ),
+        time_coordinates=np.arange(4.0),
+        event_times=np.array([1.0, 2.0, 3.0]),
+        event_indicators=np.ones(3),
+        train_event_times=np.array([1.5, 3.0]),
+        train_event_indicators=np.array([0, 1]),
+    )
+    np.testing.assert_allclose(
+        evaluator.concordance_time_dependent(method="Antolini"),
+        (2 / 3, 2.0, 3.0),
+    )
+    np.testing.assert_allclose(
+        evaluator.concordance_time_dependent(method="IPCW"),
+        (1 / 3, 2.0, 6.0),
+    )
+
+
+def test_evaluator_preserves_float32_interpolation_precision():
+    risk_gap = 1.2e-8
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.array([[1.0, 0.0], [1.0, 0.0]], dtype=np.float32),
+        time_coordinates=np.array(
+            [
+                [0.0, 1 / (0.5 + risk_gap)],
+                [0.0, 2.0],
+            ]
+        ),
+        event_times=np.array([1.0, 2.0]),
+        event_indicators=np.array([1, 0]),
+    )
+    np.testing.assert_allclose(
+        evaluator.concordance_time_dependent(risks="Survival"),
+        (1.0, 1.0, 1.0),
+    )
+
+
+def test_hazard_evaluator_only_predicts_subject_prefixes():
+    time_grids = np.array(
+        [
+            [0.0, 1.0, 4.0, 8.0, 12.0],
+            [0.0, 0.5, 1.0, 1.5, 2.0],
+            [0.0, 1.0, 4.0, 8.0, 12.0],
+            [0.0, 1.0, 4.0, 8.0, 12.0],
+        ]
+    )
+    hazards = np.array([0.5, 0.4, 0.3, 0.2])
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.exp(-hazards[:, None] * time_grids),
+        time_coordinates=time_grids,
+        event_times=np.array([1.0, 2.0, 10.0, 12.0]),
+        event_indicators=np.array([1, 0, 1, 0]),
+    )
+    with pytest.raises(ValueError, match="largest time coordinate"):
+        evaluator.predict_multi_hazards_from_curve(np.array([1.0, 10.0]))
+    np.testing.assert_allclose(
+        evaluator.concordance_time_dependent(
+            risks="Hazard",
+            working_memory=1e-6,
+        ),
+        (1.0, 4.0, 4.0),
+    )
+
+
+def test_evaluator_tau_excludes_boundary_anchor_but_keeps_later_candidates():
+    grid = np.array([0.0, 1.0, 2.0, 3.0])
+    hazards = np.array([0.5, 0.3, 0.1, 0.05])
+    evaluator = SurvivalEvaluator(
+        pred_survs=np.exp(-hazards[:, None] * grid),
+        time_coordinates=grid,
+        event_times=np.array([1.0, 2.0, 10.0, 12.0]),
+        event_indicators=np.array([1, 1, 1, 0]),
+        train_event_times=np.array([1.0, 2.0, 3.0, 4.0]),
+        train_event_indicators=np.ones(4),
+    )
+    np.testing.assert_allclose(
+        evaluator.concordance_time_dependent(
+            method="IPCW",
+            risks="Hazard",
+            tau=2.0,
+        ),
+        (1.0, 3.0, 3.0),
+    )
+
+
+def test_evaluator_streams_only_compact_prefixes_with_bounded_rows(monkeypatch):
+    n_samples = 80
+    time_grid = np.linspace(0.0, 10.0, 12)
+    hazards = np.linspace(0.5, 0.05, n_samples)
     evaluator = SurvivalEvaluator(
         pred_survs=np.exp(-hazards[:, None] * time_grid),
         time_coordinates=time_grid,
-        event_times=np.array([1.0, 1.0, 2.0, 3.0]),
-        event_indicators=np.ones(4),
+        event_times=np.linspace(0.1, 9.9, n_samples),
+        event_indicators=np.ones(n_samples),
+    )
+    calls = []
+    original = evaluator._fill_multi_curve_predictions
+
+    def record_fill(
+        output,
+        sample_indices,
+        survival_curves,
+        time_grids,
+        target_times,
+        predictor,
+        target_counts=None,
+    ):
+        calls.append(
+            (
+                output.shape,
+                output.nbytes,
+                target_times.size,
+                target_counts.copy(),
+                output.flags.f_contiguous,
+            )
+        )
+        return original(
+            output,
+            sample_indices,
+            survival_curves,
+            time_grids,
+            target_times,
+            predictor,
+            target_counts,
+        )
+
+    monkeypatch.setattr(evaluator, "_fill_multi_curve_predictions", record_fill)
+    working_memory = 0.005
+    budget = int(working_memory * (1 << 20))
+    result = evaluator.concordance_time_dependent(working_memory=working_memory)
+
+    assert len(calls) > 1
+    assert all(nbytes <= budget for _, nbytes, _, _, _ in calls)
+    assert all(shape != (n_samples, n_samples - 1) for shape, *_ in calls)
+    assert all(fortran_order for *_, fortran_order in calls)
+    assert all(np.all(counts[:-1] <= counts[1:]) for *_, counts, _ in calls)
+    pair_count = n_samples * (n_samples - 1) / 2
+    np.testing.assert_allclose(result, (1.0, pair_count, pair_count))
+
+
+def test_one_complete_compact_row_is_the_minimum_buffer(monkeypatch):
+    event_times = np.arange(1, 10, dtype=float)
+    risk_times = event_times[:-1]
+    risk_scores = np.broadcast_to(
+        np.arange(9, 0, -1, dtype=float)[:, None],
+        (9, risk_times.size),
+    ).copy()
+    output_shapes = []
+    original = td_concordance._fill_matrix_risk_batch
+
+    def record_fill(*args):
+        output_shapes.append(args[-1].shape)
+        return original(*args)
+
+    monkeypatch.setattr(td_concordance, "_fill_matrix_risk_batch", record_fill)
+    result = concordance_time_dependent(
+        risk_scores,
+        risk_times,
+        event_times,
+        np.ones(9),
+        working_memory=1 / (1 << 20),
+    )
+    assert output_shapes
+    assert all(rows == 1 for rows, _ in output_shapes)
+    assert max(columns for _, columns in output_shapes) == risk_times.size
+    np.testing.assert_allclose(result, (1.0, 36.0, 36.0))
+
+
+def test_interleaved_extra_coordinates_do_not_inflate_compact_buffer(monkeypatch):
+    n_samples = 32
+    event_times = np.arange(1, n_samples + 1, dtype=float)
+    risk_times = np.arange(0.5, n_samples + 0.5, 0.5)
+    risk_scores = np.empty((n_samples, risk_times.size))
+    risk_scores[:, ::2] = 1000.0
+    risk_scores[:, 1::2] = np.arange(n_samples, 0, -1)[:, None]
+    seen_required_columns = []
+    seen_output_columns = []
+    original = td_concordance._fill_matrix_risk_batch
+
+    def record_fill(scores, required_columns, indices, prefixes, output):
+        seen_required_columns.append(required_columns.copy())
+        seen_output_columns.append(output.shape[1])
+        return original(scores, required_columns, indices, prefixes, output)
+
+    monkeypatch.setattr(td_concordance, "_fill_matrix_risk_batch", record_fill)
+    result = concordance_time_dependent(
+        risk_scores,
+        risk_times,
+        event_times,
+        np.ones(n_samples),
+        working_memory=0.001,
     )
 
-    original_predict = getattr(evaluator, prediction_method)
-    predicted_at = []
+    expected_columns = np.arange(1, risk_times.size - 1, 2)
+    assert seen_required_columns
+    assert all(
+        np.array_equal(columns, expected_columns) for columns in seen_required_columns
+    )
+    assert max(seen_output_columns) == n_samples - 1
+    assert max(seen_output_columns) < risk_times.size
+    pair_count = n_samples * (n_samples - 1) / 2
+    np.testing.assert_allclose(result, (1.0, pair_count, pair_count))
 
-    def recording_predict(target_times):
-        predicted_at.append(target_times.copy())
-        return original_predict(target_times)
 
-    monkeypatch.setattr(evaluator, prediction_method, recording_predict)
+def test_matrix_filler_uses_unbuffered_take_mode(monkeypatch):
+    calls = []
+    original_take = td_concordance.np.take
 
-    result = evaluator.concordance_time_dependent(risks=risks)
+    def record_take(array, indices, *, out, mode):
+        calls.append((array.ndim, out.ndim, mode, out.size))
+        return original_take(array, indices, out=out, mode=mode)
 
-    assert len(predicted_at) == 1
-    np.testing.assert_array_equal(predicted_at[0], [1.0, 2.0])
-    np.testing.assert_allclose(result, (1.0, 5.0, 5.0))
+    monkeypatch.setattr(td_concordance.np, "take", record_take)
+    concordance_time_dependent(
+        np.array([[3.0, 0.0], [2.0, 2.0], [1.0, 1.0]]),
+        np.array([1.0, 2.0]),
+        np.array([1.0, 2.0, 3.0]),
+        np.ones(3),
+        working_memory=1e-6,
+    )
+    assert calls
+    assert all(
+        input_ndim == output_ndim == 1 for input_ndim, output_ndim, _, _ in calls
+    )
+    assert all(mode == "clip" for _, _, mode, _ in calls)
+
+
+def test_matrix_path_peak_memory_excludes_second_risk_batch():
+    n_samples = 512
+    event_times = np.arange(1, n_samples + 1, dtype=float)
+    risk_times = event_times[:-1]
+    risk_scores = np.broadcast_to(
+        np.arange(n_samples, 0, -1, dtype=float)[:, None],
+        (n_samples, risk_times.size),
+    ).copy()
+    working_memory = 0.25
+    budget = int(working_memory * (1 << 20))
+
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+    baseline, _ = tracemalloc.get_traced_memory()
+    tracemalloc.reset_peak()
+    try:
+        result = concordance_time_dependent(
+            risk_scores,
+            risk_times,
+            event_times,
+            np.ones(n_samples),
+            working_memory=working_memory,
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        if not was_tracing:
+            tracemalloc.stop()
+
+    # The compact risk buffer is one budget; O(n) layout and 1-D workspaces fit
+    # well below the allowance that a second output-sized buffer would consume.
+    assert peak - baseline < 1.6 * budget
+    pair_count = n_samples * (n_samples - 1) / 2
+    np.testing.assert_allclose(result, (1.0, pair_count, pair_count))


### PR DESCRIPTION
## Summary

- Reimplement time-dependent concordance from the `v0.8.2` base around one sorted event-block layout and one memory-bounded counting kernel.
- Stream only required per-subject risk prefixes, extract anchor risks from the same batches, and avoid full sample-by-event-time matrices or per-pair index and weight arrays.
- Preserve Antolini, Naive, explicit IPCW, all tie policies, strict `tau`, survival risks, hazard risks, and exact numeric behavior at mixed-dtype boundaries.

## API change

- `concordance_time_dependent` now requires explicit, finite, non-negative, strictly increasing `risk_times` alongside `risk_scores`.
- Repeated event times share one risk column, while unused extra coordinates are accepted.
- Both the lower-level function and `SurvivalEvaluator.concordance_time_dependent` expose `working_memory=256` as the compact risk-buffer target in MiB, with one complete compact row as the minimum.
- The previous event-per-column lower-level convention is intentionally removed.

## Implementation

- Centralizes validation for real finite risks, finite non-negative times, binary indicators, scalar `tau` and memory values, required risk coordinates, and IPCW training support.
- Uses an exact binary-search fallback only when NumPy promotion would lose precision. Integers and NumPy floating scalars, including wider `longdouble` values, are compared through exact integer ratios without narrowing to Python `float`. This covers `2**24`, `2**53`, signed/unsigned boundaries, strict `tau`, training support, and right-continuous Kaplan-Meier lookup.
- Sorts test subjects once with events before same-time censorings. Each event block records its candidate suffix, shared risk time, time ties, and each subject's required risk-time prefix.
- Compares integer risks with exact bounded comparisons and floating risks in a promoted floating dtype while reusing one-dimensional work buffers.
- Stores one IPCW weight per event-time block using `1 / G(t)^2`; explicit IPCW remains active even for fully observed test outcomes.
- Copies matrix-backed batches with unbuffered one-dimensional `numpy.take(..., mode="clip")` calls, so no second output-sized temporary is created.

The implementation takes `O(n log n + R + P)` time and `O(n + Bm + B)` auxiliary space, where `P` is the number of comparable directed pairs, `R` is the number of streamed risk cells, `m` is the number of contributing event times, and `B` is the memory-budgeted batch size.

## Verification

- Focused independent-oracle and structural suite: **84 passed, 2 platform-gated tests skipped**.
- Broad repository suite excluding only unavailable-data cases: **293 passed, 2 platform-gated tests skipped, 1 unavailable-data test deselected**.
- Changed-file Ruff checks and format verification passed (excluding the repository's existing CamelCase-module `N999` naming convention).
- Python bytecode compilation and `git diff --check` passed.

The two new `longdouble` regressions run when `np.longdouble` has more precision than `float64`; they are skipped on macOS platforms where those dtypes have equal precision.

The unfiltered suite still has two pre-existing data blockers: `tests/test_single_event.py` references a developer-local absolute `breast.csv` path during collection, and `test_interval_cen_evaluator_methods` expects the absent repository file `data/breast.csv`. These were reported separately rather than masked.
